### PR TITLE
Add pause and resume connector commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Commands:
   apply     Applies the given file for registering or updating a connector
   patch     Modifies the configuration of a connector or logger
   restart   Restarts a connector or task
+  pause     Pauses a connector
+  resume    Resumes a connector
   delete    Deletes the specified connector
   help      Displays help information about the specified command
 ```

--- a/src/main/java/dev/morling/kccli/command/KcCtlCommand.java
+++ b/src/main/java/dev/morling/kccli/command/KcCtlCommand.java
@@ -28,6 +28,7 @@ import picocli.CommandLine;
         PatchCommand.class,
         RestartCommand.class,
         PauseCommand.class,
+        ResumeCommand.class,
         DeleteConnectorCommand.class,
         CommandLine.HelpCommand.class,
         ConnectorNamesCompletionCandidateCommand.class,

--- a/src/main/java/dev/morling/kccli/command/KcCtlCommand.java
+++ b/src/main/java/dev/morling/kccli/command/KcCtlCommand.java
@@ -27,6 +27,7 @@ import picocli.CommandLine;
         ApplyCommand.class,
         PatchCommand.class,
         RestartCommand.class,
+        PauseCommand.class,
         DeleteConnectorCommand.class,
         CommandLine.HelpCommand.class,
         ConnectorNamesCompletionCandidateCommand.class,

--- a/src/main/java/dev/morling/kccli/command/PauseCommand.java
+++ b/src/main/java/dev/morling/kccli/command/PauseCommand.java
@@ -1,0 +1,22 @@
+/*
+ *  Copyright 2021 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package dev.morling.kccli.command;
+
+import picocli.CommandLine.Command;
+
+@Command(name = "pause", subcommands = { PauseConnectorCommand.class }, description = "Pauses a connector")
+public class PauseCommand {
+}

--- a/src/main/java/dev/morling/kccli/command/PauseConnectorCommand.java
+++ b/src/main/java/dev/morling/kccli/command/PauseConnectorCommand.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2021 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package dev.morling.kccli.command;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+
+import dev.morling.kccli.service.KafkaConnectApi;
+import dev.morling.kccli.util.ConfigurationContext;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+@Command(name = "connector", description = "Pauses the specified connector")
+public class PauseConnectorCommand implements Runnable {
+
+    @Inject
+    ConfigurationContext context;
+
+    @Parameters(paramLabel = "NAME", description = "Name of the connector (e.g. 'my-connector')") // , completionCandidates = DummyCompletions.class)
+    String name;
+
+    @Override
+    public void run() {
+        KafkaConnectApi kafkaConnectApi = RestClientBuilder.newBuilder()
+                .baseUri(context.getCluster())
+                .build(KafkaConnectApi.class);
+
+        kafkaConnectApi.pauseConnector(name);
+        System.out.println("Paused connector " + name);
+    }
+}

--- a/src/main/java/dev/morling/kccli/command/ResumeCommand.java
+++ b/src/main/java/dev/morling/kccli/command/ResumeCommand.java
@@ -1,0 +1,22 @@
+/*
+ *  Copyright 2021 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package dev.morling.kccli.command;
+
+import picocli.CommandLine.Command;
+
+@Command(name = "resume", subcommands = { ResumeConnectorCommand.class }, description = "Resumes a connector")
+public class ResumeCommand {
+}

--- a/src/main/java/dev/morling/kccli/command/ResumeConnectorCommand.java
+++ b/src/main/java/dev/morling/kccli/command/ResumeConnectorCommand.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2021 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package dev.morling.kccli.command;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+
+import dev.morling.kccli.service.KafkaConnectApi;
+import dev.morling.kccli.util.ConfigurationContext;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+@Command(name = "connector", description = "Resumes the specified connector")
+public class ResumeConnectorCommand implements Runnable {
+
+    @Inject
+    ConfigurationContext context;
+
+    @Parameters(paramLabel = "NAME", description = "Name of the connector (e.g. 'my-connector')") // , completionCandidates = DummyCompletions.class)
+    String name;
+
+    @Override
+    public void run() {
+        KafkaConnectApi kafkaConnectApi = RestClientBuilder.newBuilder()
+                .baseUri(context.getCluster())
+                .build(KafkaConnectApi.class);
+
+        kafkaConnectApi.resumeConnector(name);
+        System.out.println("Resumed connector " + name);
+    }
+}

--- a/src/main/java/dev/morling/kccli/service/KafkaConnectApi.java
+++ b/src/main/java/dev/morling/kccli/service/KafkaConnectApi.java
@@ -62,6 +62,10 @@ public interface KafkaConnectApi {
     @Path("/connectors/{name}/pause")
     void pauseConnector(@PathParam("name") String name);
 
+    @PUT
+    @Path("/connectors/{name}/resume")
+    void resumeConnector(@PathParam("name") String name);
+
     @DELETE
     @Path("/connectors/{name}")
     void deleteConnector(@PathParam("name") String name);

--- a/src/main/java/dev/morling/kccli/service/KafkaConnectApi.java
+++ b/src/main/java/dev/morling/kccli/service/KafkaConnectApi.java
@@ -58,6 +58,10 @@ public interface KafkaConnectApi {
     @Path("/connectors/{name}/restart")
     void restartConnector(@PathParam("name") String name);
 
+    @PUT
+    @Path("/connectors/{name}/pause")
+    void pauseConnector(@PathParam("name") String name);
+
     @DELETE
     @Path("/connectors/{name}")
     void deleteConnector(@PathParam("name") String name);


### PR DESCRIPTION
Add two new commands to support pause and resume kafka connectors #1 

1- `kcctl pause connector connector-name-1`
2- `kcctl resume connector connector-name-1`