### PR TITLE
Initial config validation logic

### DIFF
--- a/kcctl_completion
+++ b/kcctl_completion
@@ -261,7 +261,7 @@ function _picocli_kcctl_apply() {
   local prev_word=${COMP_WORDS[COMP_CWORD-1]}
 
   local commands=""
-  local flag_opts=""
+  local flag_opts="--dry-run"
   local arg_opts="-f --file -n --name"
 
   compopt +o default

--- a/src/main/java/dev/morling/kccli/command/ApplyCommand.java
+++ b/src/main/java/dev/morling/kccli/command/ApplyCommand.java
@@ -136,11 +136,10 @@ public class ApplyCommand implements Callable<Integer> {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     private int validateConfigs(KafkaConnectApi kafkaConnectApi, Map<String, Object> config) throws Exception {
-        if (!config.containsKey("config")) {
-            System.out.println("The file must contain the 'config' field.");
-            return 1;
-        }
-        Map<String, String> connectorConfigMap = (Map) config.get("config");
+        Map<String, String> connectorConfigMap = (config.containsKey("config"))
+                ? (Map) config.get("config")
+                : (Map) config;
+
         if (!connectorConfigMap.containsKey("connector.class")) {
             System.out.println("The configuration must contain the 'connector.class' field.");
             return 1;

--- a/src/main/java/dev/morling/kccli/command/ApplyCommand.java
+++ b/src/main/java/dev/morling/kccli/command/ApplyCommand.java
@@ -18,6 +18,7 @@ package dev.morling.kccli.command;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
@@ -27,11 +28,15 @@ import org.eclipse.microprofile.rest.client.RestClientBuilder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import dev.morling.kccli.service.ConfigInfos;
 import dev.morling.kccli.service.KafkaConnectApi;
 import dev.morling.kccli.service.KafkaConnectException;
 import dev.morling.kccli.util.ConfigurationContext;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
+
+import static dev.morling.kccli.util.Colors.ANSI_RESET;
+import static dev.morling.kccli.util.Colors.ANSI_WHITE_BOLD;
 
 @Command(name = "apply", description = "Applies the given file for registering or updating a connector")
 public class ApplyCommand implements Callable<Integer> {
@@ -45,6 +50,13 @@ public class ApplyCommand implements Callable<Integer> {
     @Option(names = { "-n", "--name" }, description = "Name of the connector when not given within the file itself")
     String name;
 
+    @Option(names = { "--dry-run" }, description = "Only validates the configuration")
+    boolean dryRun;
+
+    private final static String CONFIG_EXCEPTION = "org.apache.kafka.common.config.ConfigException: ";
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @SuppressWarnings("unchecked")
     @Override
     public Integer call() throws Exception {
         KafkaConnectApi kafkaConnectApi = RestClientBuilder.newBuilder()
@@ -56,7 +68,7 @@ public class ApplyCommand implements Callable<Integer> {
             return 1;
         }
 
-        String contents = null;
+        String contents;
         try {
             contents = Files.readString(file.toPath());
         }
@@ -64,19 +76,28 @@ public class ApplyCommand implements Callable<Integer> {
             throw new RuntimeException("Couldn't read file", e);
         }
 
-        ObjectMapper mapper = new ObjectMapper();
         Map<String, Object> config = mapper.readValue(contents, Map.class);
 
+        if (dryRun) {
+            return validateConfigs(kafkaConnectApi, config);
+        }
+        else {
+            return createOrUpdateConnector(kafkaConnectApi, contents, config);
+        }
+    }
+
+    private int createOrUpdateConnector(KafkaConnectApi kafkaConnectApi, String contents, Map<String, Object> config) throws Exception {
         try {
             if (config.containsKey("name") && config.containsKey("config")) {
-                boolean existing = kafkaConnectApi.getConnectors().contains(config.get("name"));
+                String connectorName = (String) config.get("name");
+                boolean existing = kafkaConnectApi.getConnectors().contains(connectorName);
                 if (!existing) {
                     kafkaConnectApi.createConnector(contents);
-                    System.out.println("Created connector " + config.get("name"));
+                    System.out.println("Created connector " + connectorName);
                 }
                 else {
-                    kafkaConnectApi.updateConnector((String) config.get("name"), mapper.writeValueAsString(config.get("config")));
-                    System.out.println("Updated connector " + config.get("name"));
+                    kafkaConnectApi.updateConnector(connectorName, mapper.writeValueAsString(config.get("config")));
+                    System.out.println("Updated connector " + connectorName);
                 }
             }
             else {
@@ -108,6 +129,59 @@ public class ApplyCommand implements Callable<Integer> {
             getPlugins.run();
 
             return 1;
+        }
+
+        return 0;
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private int validateConfigs(KafkaConnectApi kafkaConnectApi, Map<String, Object> config) throws Exception {
+        if (!config.containsKey("config")) {
+            System.out.println("The file must contain the 'config' field.");
+            return 1;
+        }
+        Map<String, String> connectorConfigMap = (Map) config.get("config");
+        if (!connectorConfigMap.containsKey("connector.class")) {
+            System.out.println("The configuration must contain the 'connector.class' field.");
+            return 1;
+        }
+        // In order to start a connector, "name" is not required within "config". However, when validating a
+        // configuration it is! So injecting a placeholder to make sure this does not fail validation.
+        connectorConfigMap.putIfAbsent("name", "dummy-name");
+
+        String clazz = connectorConfigMap.get("connector.class");
+        String pluginName = clazz.substring(clazz.lastIndexOf('.') + 1);
+        try {
+            ConfigInfos configInfos = kafkaConnectApi.validateConfig(pluginName, mapper.writeValueAsString(connectorConfigMap));
+            int errs = configInfos.errorCount;
+            if (errs == 0) {
+                System.out.println("The configuration is valid!");
+            }
+            else {
+                System.out.println("The configuration is not valid! Found " + errs + " error" + ((errs != 1) ? "s" : "") + ".");
+                System.out.println(ANSI_WHITE_BOLD + "Errors" + ANSI_RESET);
+                for (ConfigInfos.ConfigInfo configInfo : configInfos.configs) {
+                    List<String> errors = configInfo.configValue.errors;
+                    if (errors != null && !errors.isEmpty()) {
+                        System.out.println("  " + configInfo.configKey.name);
+                        for (String error : errors) {
+                            System.out.println("    " + error);
+                        }
+                    }
+                }
+                return 1;
+            }
+        }
+        catch (KafkaConnectException kce) {
+            if (kce.getMessage().startsWith(CONFIG_EXCEPTION)) {
+                System.out.println("The configuration is not valid! Found 1 error.");
+                System.out.println(ANSI_WHITE_BOLD + "Errors" + ANSI_RESET);
+                System.out.println("  " + kce.getMessage().replace(CONFIG_EXCEPTION, ""));
+                return 1;
+            }
+            else {
+                throw kce;
+            }
         }
 
         return 0;

--- a/src/main/java/dev/morling/kccli/service/ConfigInfos.java
+++ b/src/main/java/dev/morling/kccli/service/ConfigInfos.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright 2021 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package dev.morling.kccli.service;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ConfigInfos {
+
+    public String name;
+    @JsonProperty("error_count")
+    public int errorCount;
+    public List<String> groups;
+    public List<ConfigInfo> configs;
+
+    public static class ConfigInfo {
+        @JsonProperty("definition")
+        public ConfigKeyInfo configKey;
+        @JsonProperty("value")
+        public ConfigValueInfo configValue;
+    }
+
+    public static class ConfigKeyInfo {
+        public String name;
+        public String type;
+        public boolean required;
+        public String defaultValue;
+        public String importance;
+        public String documentation;
+        public String group;
+        public int orderInGroup;
+        public String width;
+        public String displayName;
+        public List<String> dependents;
+    }
+
+    public static class ConfigValueInfo {
+        public String name;
+        public String value;
+        public List<String> recommendedValues;
+        public List<String> errors;
+        public boolean visible;
+    }
+
+}

--- a/src/main/java/dev/morling/kccli/service/KafkaConnectApi.java
+++ b/src/main/java/dev/morling/kccli/service/KafkaConnectApi.java
@@ -42,6 +42,10 @@ public interface KafkaConnectApi {
     @Path("/connector-plugins")
     List<ConnectorPlugin> getConnectorPlugins();
 
+    @PUT
+    @Path("/connector-plugins/{name}/config/validate")
+    ConfigInfos validateConfig(@PathParam("name") String name, String config);
+
     @GET
     @Path("/connectors/")
     List<String> getConnectors();


### PR DESCRIPTION
I've been playing quite a bit with the `/config/validate` endpoint in the past couple of days, so I thought I'd try adding support for it!

I've added it to `apply`, so currently the syntax to validate a configuration is:
```
kcctl apply -f /tmp/config.json --validate
```

Not fully sold on the flag name, maybe `--validate-only` is more explicit.

It's working with the same file as when creating a connector. Internally, it's hiding that `/config/validate` only wants the inner `config` part. I think it makes sense to validate and create connectors with the same exact file. I'm not a big fan of the Connect REST API expecting different payloads for both operations.

I've not properly tested all possible error paths yet but I wanted to see if the overall shape is what you had in mind.