### PR TITLE
Feature/broker auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ It is recommended to install the bash/zsh completion script _kcctl_completion_:
 Before you can start using _kcctl_ you need to create a configuration context.
 A configuration context is a set of configuration parameters, grouped
 by a name.
-To create a configuration context named `local`, with the Kafka Connect cluster URL set to 
+To create a configuration context named `local`, with the Kafka Connect cluster URL set to
 `http://localhost:8083`, issue the following command
 
 ```shell script
 kcctl config set-context local --cluster http://localhost:8083
 ```
 
-:exclamation: Note that certain commands will require additional parameters, like `bootstrap-servers` and 
+:exclamation: Note that certain commands will require additional parameters, like `bootstrap-servers` and
 `offset-topic`.
 
 Type `kcctl info` to display some information about the Kafka Connect cluster.
@@ -48,10 +48,13 @@ resolve the cluster URL.
 ## Authentication
 
 If your cluster enforces authentication, you may configure your username and password with the `username` and `password` parameters:
+
 ```shell script
 kcctl config set-context local --cluster http://localhost:8083 --username myusername --password mypassword
 ```
+
 :exclamation: Note that setting user name and password via CLI may store those credentials in your terminal history. To work around this, you may set the username and password directly in your `.kcctl` file:
+
 ```json
   "currentContext" : "local",
   "local" : {
@@ -60,6 +63,7 @@ kcctl config set-context local --cluster http://localhost:8083 --username myuser
     "password" : "mypassword"
   }
 ```
+
 Currently, only basic authentication is supported.
 
 ## Usage
@@ -86,6 +90,7 @@ Commands:
   delete    Deletes the specified connector
   help      Displays help information about the specified command
 ```
+
 Start by running `kcctl config set-context <name> --cluster=<Kafka Connect URI)...` for setting up a configuration context which will be used by any subsequent commands.
 
 ## Development
@@ -148,7 +153,7 @@ Then recreate the completion script:
 
 ```shell script
 java -cp "target/quarkus-app/app/*:target/quarkus-app/lib/main/*:target/quarkus-app/quarkus-run.jar" \
-  picocli.AutoComplete -n kcctl --force dev.morling.kccli.command.KcCtlCommand
+  picocli.AutoComplete -n kcctl --force org.moditect.kcctl.command.KcCtlCommand
 ```
 
 Edit the completion script _kcctl_completion_, replace all the quotes around generated completion invocations with back ticks, making them actual invocations of _kcctl_::

--- a/broker-auth/jaas.config
+++ b/broker-auth/jaas.config
@@ -1,0 +1,6 @@
+KafkaServer {
+  org.apache.kafka.common.security.plain.PlainLoginModule required
+    username="admin"
+    password="admin-secret"
+    user_admin="admin-secret";
+};

--- a/broker-auth/zk.jaas.config
+++ b/broker-auth/zk.jaas.config
@@ -1,0 +1,6 @@
+Server {
+  org.apache.kafka.common.security.plain.PlainLoginModule required
+    username="admin"
+    password="admin-secret"
+    user_admin="admin-secret";
+};

--- a/docker-compose.broker-auth.yml
+++ b/docker-compose.broker-auth.yml
@@ -1,0 +1,63 @@
+#
+#  Copyright 2021 The original authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+version: "2"
+services:
+  zookeeper:
+    image: debezium/zookeeper:1.7
+    ports:
+      - 2181:2181
+      - 2888:2888
+      - 3888:3888
+    #volumes:
+    #  - ./broker-auth:/kafka/config/broker-auth
+    #environment:
+    #  - KAFKA_OPTS=-Djava.security.auth.login.config=/kafka/config/broker-auth/zk.jaas.config
+  kafka:
+    image: debezium/kafka:1.7
+    ports:
+      - 9092:9092
+    depends_on:
+      - zookeeper
+    volumes:
+      - ./broker-auth:/kafka/config/broker-auth
+    environment:
+      - ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_SECURITY_INTER_BROKER_PROTOCOL=SASL_PLAINTEXT
+      - KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL=PLAIN
+      - KAFKA_SECURITY_PROTOCOL=SASL_PLAINTEXT
+      - KAFKA_SASL_ENABLED_MECHANISMS=PLAIN
+      - KAFKA_LISTENERS=SASL_PLAINTEXT://0.0.0.0:9092
+      - KAFKA_ADVERTISED_LISTENERS=SASL_PLAINTEXT://kafka:9092
+      - KAFKA_OPTS=-Djava.security.auth.login.config=/kafka/config/broker-auth/jaas.config
+      - KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND=true
+      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
+  connect:
+    image: debezium/connect-base:1.7
+    hostname: connect
+    ports:
+      - 8083:8083
+    depends_on:
+      - kafka
+    environment:
+      - BOOTSTRAP_SERVERS=kafka:9092
+      - GROUP_ID=1
+      - CONFIG_STORAGE_TOPIC=my_connect_configs
+      - OFFSET_STORAGE_TOPIC=my_connect_offsets
+      - STATUS_STORAGE_TOPIC=my_connect_statuses
+      - CONNECT_SECURITY_PROTOCOL=SASL_PLAINTEXT
+      - CONNECT_SASL_MECHANISM=PLAIN
+      - CONNECT_SASL_JAAS_CONFIG=org.apache.kafka.common.security.plain.PlainLoginModule required username=\"admin\" password=\"admin-secret\" user_admin=\"admin-secret\";

--- a/kcctl_completion
+++ b/kcctl_completion
@@ -405,7 +405,7 @@ function _picocli_kcctl_config_setcontext() {
 
   local commands=""
   local flag_opts=""
-  local arg_opts="--cluster --bootstrap-servers --offset-topic --username --password"
+  local arg_opts="--cluster --bootstrap-servers --offset-topic --username --password -o --client-config -f --client-config-file"
 
   compopt +o default
 
@@ -423,6 +423,12 @@ function _picocli_kcctl_config_setcontext() {
       return
       ;;
     --password)
+      return
+      ;;
+    -o|--client-config)
+      return
+      ;;
+    -f|--client-config-file)
       return
       ;;
   esac

--- a/src/main/java/org/moditect/kcctl/command/DescribeConnectorCommand.java
+++ b/src/main/java/org/moditect/kcctl/command/DescribeConnectorCommand.java
@@ -63,6 +63,7 @@ public class DescribeConnectorCommand implements Callable<Integer> {
 
     @Override
     public Integer call() {
+
         KafkaConnectApi kafkaConnectApi = RestClientBuilder.newBuilder()
                 .baseUri(context.getCurrentContext().getCluster())
                 .build(KafkaConnectApi.class);

--- a/src/main/java/org/moditect/kcctl/command/PatchConnectorCommand.java
+++ b/src/main/java/org/moditect/kcctl/command/PatchConnectorCommand.java
@@ -20,6 +20,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 
@@ -58,7 +59,7 @@ public class PatchConnectorCommand implements Callable<Integer> {
     List<String> removeParameters;
 
     @Override
-    public Integer call() throws JsonProcessingException {
+    public Integer call() throws JsonProcessingException, InterruptedException, ExecutionException {
 
         KafkaConnectApi kafkaConnectApi = RestClientBuilder.newBuilder()
                 .baseUri(context.getCurrentContext().getCluster())

--- a/src/main/java/org/moditect/kcctl/command/SetContextCommand.java
+++ b/src/main/java/org/moditect/kcctl/command/SetContextCommand.java
@@ -49,28 +49,28 @@ public class SetContextCommand implements Callable<Integer> {
     @Option(names = { "--password" }, description = "Password for basic authentication")
     String password;
 
-    @Option(names = { "--admin-client-config" }, description = "Configuration for admin client")
-    String adminClientConfig;
+    @Option(names = { "--client-config" }, description = "Configuration for admin client")
+    String clientConfig;
 
     @Override
     public Integer call() {
         ConfigurationContext context = new ConfigurationContext();
 
-        Properties adminClientConfigProps;
+        Properties clientConfigProps;
         try {
-            adminClientConfigProps = Strings.toProperties(adminClientConfig);
+            clientConfigProps = Strings.toProperties(clientConfig);
         }
         catch (Exception exception) {
             System.out.println("The provided admin client configuration is not valid!");
             return 1;
         }
 
-        final var adminClientConfigMap = new HashMap<String, Object>();
-        for (final String name : adminClientConfigProps.stringPropertyNames()) {
-            adminClientConfigMap.put(name, adminClientConfigProps.getProperty(name));
+        final var clientConfigMap = new HashMap<String, Object>();
+        for (final String name : clientConfigProps.stringPropertyNames()) {
+            clientConfigMap.put(name, clientConfigProps.getProperty(name));
         }
 
-        context.setContext(contextName, new Context(URI.create(cluster), bootstrapServers, offsetTopic, username, password, adminClientConfigMap));
+        context.setContext(contextName, new Context(URI.create(cluster), bootstrapServers, offsetTopic, username, password, clientConfigMap));
         System.out.println("Configured context " + contextName);
 
         if (!context.getCurrentContextName().equals(contextName)) {

--- a/src/main/java/org/moditect/kcctl/command/SetContextCommand.java
+++ b/src/main/java/org/moditect/kcctl/command/SetContextCommand.java
@@ -19,6 +19,7 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Properties;
 import java.util.concurrent.Callable;
@@ -65,23 +66,24 @@ public class SetContextCommand implements Callable<Integer> {
         Properties clientConfigProps = new Properties();
 
         if (!Strings.isBlank(clientConfigFile)) {
-            final String expandedPath = clientConfigFile.replaceFirst("^~", System.getProperty("user.home"));
+            final String expandedPath = Paths.get(clientConfigFile).toAbsolutePath().toString();
             clientConfigProps.load(new FileReader(expandedPath));
         }
 
-        for (final String clientConfigString : this.clientConfigs) {
-            try {
-                clientConfigProps.putAll(Strings.toProperties(clientConfigString));
-            }
-            catch (Exception exception) {
-                System.out.println("The provided client configuration is not valid!");
-                return 1;
+        if (this.clientConfigs != null) {
+            for (final String clientConfigString : this.clientConfigs) {
+                try {
+                    clientConfigProps.putAll(Strings.toProperties(clientConfigString));
+                }
+                catch (Exception exception) {
+                    System.out.println("The provided client configuration is not valid!");
+                    return 1;
+                }
             }
         }
 
         final var clientConfigMap = new HashMap<String, Object>();
         for (final String name : clientConfigProps.stringPropertyNames()) {
-            System.out.println("[" + name + "]: " + clientConfigProps.getProperty(name));
             clientConfigMap.put(name, clientConfigProps.getProperty(name));
         }
 
@@ -94,4 +96,5 @@ public class SetContextCommand implements Callable<Integer> {
 
         return 0;
     }
+
 }

--- a/src/main/java/org/moditect/kcctl/service/Context.java
+++ b/src/main/java/org/moditect/kcctl/service/Context.java
@@ -16,6 +16,7 @@
 package org.moditect.kcctl.service;
 
 import java.net.URI;
+import java.util.Map;
 
 import org.moditect.kcctl.util.Strings;
 
@@ -28,18 +29,21 @@ public class Context {
     private final String offsetTopic;
     private final String username;
     private final String password;
+    private final Map<String, Object> adminClientConfig;
 
     public Context(
                    @JsonProperty("cluster") URI cluster,
                    @JsonProperty("bootstrapServers") String bootstrapServers,
                    @JsonProperty("offsetTopic") String offsetTopic,
                    @JsonProperty("username") String username,
-                   @JsonProperty("password") String password) {
+                   @JsonProperty("password") String password,
+                   @JsonProperty("adminClientConfig") Map<String, Object> adminClientConfig) {
         this.cluster = cluster;
         this.bootstrapServers = bootstrapServers;
         this.offsetTopic = offsetTopic;
         this.username = username;
         this.password = password;
+        this.adminClientConfig = adminClientConfig;
     }
 
     public URI getCluster() {
@@ -62,6 +66,10 @@ public class Context {
         return password;
     }
 
+    public Map<String, Object> getAdminClientConfig() {
+        return this.adminClientConfig;
+    }
+
     @JsonIgnore
     public boolean isUsingBasicAuthentication() {
         return !Strings.isBlank(this.getUsername()) &&
@@ -69,6 +77,6 @@ public class Context {
     }
 
     public static Context defaultContext() {
-        return new Context(URI.create("http://localhost:8083"), null, null, null, null);
+        return new Context(URI.create("http://localhost:8083"), null, null, null, null, null);
     }
 }

--- a/src/main/java/org/moditect/kcctl/service/Context.java
+++ b/src/main/java/org/moditect/kcctl/service/Context.java
@@ -29,7 +29,7 @@ public class Context {
     private final String offsetTopic;
     private final String username;
     private final String password;
-    private final Map<String, Object> adminClientConfig;
+    private final Map<String, Object> clientConfig;
 
     public Context(
                    @JsonProperty("cluster") URI cluster,
@@ -37,13 +37,13 @@ public class Context {
                    @JsonProperty("offsetTopic") String offsetTopic,
                    @JsonProperty("username") String username,
                    @JsonProperty("password") String password,
-                   @JsonProperty("adminClientConfig") Map<String, Object> adminClientConfig) {
+                   @JsonProperty("clientConfig") Map<String, Object> clientConfig) {
         this.cluster = cluster;
         this.bootstrapServers = bootstrapServers;
         this.offsetTopic = offsetTopic;
         this.username = username;
         this.password = password;
-        this.adminClientConfig = adminClientConfig;
+        this.clientConfig = clientConfig;
     }
 
     public URI getCluster() {
@@ -66,8 +66,8 @@ public class Context {
         return password;
     }
 
-    public Map<String, Object> getAdminClientConfig() {
-        return this.adminClientConfig;
+    public Map<String, Object> getClientConfig() {
+        return this.clientConfig;
     }
 
     @JsonIgnore

--- a/src/main/java/org/moditect/kcctl/util/ConfigurationContext.java
+++ b/src/main/java/org/moditect/kcctl/util/ConfigurationContext.java
@@ -140,7 +140,8 @@ public class ConfigurationContext {
         catch (IOException e) {
             throw new RuntimeException("Couldn't read configuration file ~/" + CONFIG_FILE + ". If you are using the legacy," +
                     "property-based configuration format, please delete the old .kcctl file and create a new one by " +
-                    "running 'kcctl config set-context <context_name> --cluster=<cluster_url> [--bootstrap-servers=<broker_urls>] [--offset-topic=<offset_topic>] [--admin-client-config=<config_string>]. ", e);
+                    "running 'kcctl config set-context <context_name> --cluster=<cluster_url> [--bootstrap-servers=<broker_urls>] [--offset-topic=<offset_topic>] [--admin-client-config=<config_string>]. ",
+                    e);
         }
     }
 

--- a/src/main/java/org/moditect/kcctl/util/ConfigurationContext.java
+++ b/src/main/java/org/moditect/kcctl/util/ConfigurationContext.java
@@ -75,7 +75,7 @@ public class ConfigurationContext {
 
     private void warnAboutMissingConfigFile() {
         System.out.println("No configuration context has been defined, using http://localhost:8083 by default." +
-                " Run 'kcctl config set-context <context_name> --cluster=<cluster_url> [--bootstrap-servers=<broker_urls>] [--offset-topic=<offset_topic>] [--admin-client-config=<config_string>].' to create a context.");
+                " Run 'kcctl config set-context <context_name> --cluster=<cluster_url> [--bootstrap-servers=<broker_urls>] [--offset-topic=<offset_topic>] [--client-config=<config_string>].' to create a context.");
     }
 
     public Map<String, Context> getContexts() {
@@ -140,7 +140,7 @@ public class ConfigurationContext {
         catch (IOException e) {
             throw new RuntimeException("Couldn't read configuration file ~/" + CONFIG_FILE + ". If you are using the legacy," +
                     "property-based configuration format, please delete the old .kcctl file and create a new one by " +
-                    "running 'kcctl config set-context <context_name> --cluster=<cluster_url> [--bootstrap-servers=<broker_urls>] [--offset-topic=<offset_topic>] [--admin-client-config=<config_string>]. ",
+                    "running 'kcctl config set-context <context_name> --cluster=<cluster_url> [--bootstrap-servers=<broker_urls>] [--offset-topic=<offset_topic>] [---client-config=<config_string>]. ",
                     e);
         }
     }
@@ -152,7 +152,7 @@ public class ConfigurationContext {
         catch (IOException e) {
             throw new RuntimeException("Couldn't write configuration file " + configFile + ". If you are using the legacy," +
                     "property-based configuration format, please delete the old .kcctl file and create a new one by " +
-                    "running 'kcctl config set-context <context_name> --cluster=<cluster_url> [--bootstrap-servers=<broker_urls>] [--offset-topic=<offset_topic>] [--admin-client-config=<config_string>]. ",
+                    "running 'kcctl config set-context <context_name> --cluster=<cluster_url> [--bootstrap-servers=<broker_urls>] [--offset-topic=<offset_topic>] [--client-config=<config_string>]. ",
                     e);
         }
     }

--- a/src/main/java/org/moditect/kcctl/util/ConfigurationContext.java
+++ b/src/main/java/org/moditect/kcctl/util/ConfigurationContext.java
@@ -75,7 +75,7 @@ public class ConfigurationContext {
 
     private void warnAboutMissingConfigFile() {
         System.out.println("No configuration context has been defined, using http://localhost:8083 by default." +
-                " Run 'kcctl config set-context <context_name> --cluster=<cluster_url> [--bootstrap-servers=<broker_urls>] [--offset-topic=<offset_topic>].' to create a context.");
+                " Run 'kcctl config set-context <context_name> --cluster=<cluster_url> [--bootstrap-servers=<broker_urls>] [--offset-topic=<offset_topic>] [--admin-client-config=<config_string>].' to create a context.");
     }
 
     public Map<String, Context> getContexts() {
@@ -140,7 +140,7 @@ public class ConfigurationContext {
         catch (IOException e) {
             throw new RuntimeException("Couldn't read configuration file ~/" + CONFIG_FILE + ". If you are using the legacy," +
                     "property-based configuration format, please delete the old .kcctl file and create a new one by " +
-                    "running 'kcctl config set-context <context_name> --cluster=<cluster_url> [--bootstrap-servers=<broker_urls>] [--offset-topic=<offset_topic>]. ", e);
+                    "running 'kcctl config set-context <context_name> --cluster=<cluster_url> [--bootstrap-servers=<broker_urls>] [--offset-topic=<offset_topic>] [--admin-client-config=<config_string>]. ", e);
         }
     }
 
@@ -151,7 +151,8 @@ public class ConfigurationContext {
         catch (IOException e) {
             throw new RuntimeException("Couldn't write configuration file " + configFile + ". If you are using the legacy," +
                     "property-based configuration format, please delete the old .kcctl file and create a new one by " +
-                    "running 'kcctl config set-context <context_name> --cluster=<cluster_url> [--bootstrap-servers=<broker_urls>] [--offset-topic=<offset_topic>]. ", e);
+                    "running 'kcctl config set-context <context_name> --cluster=<cluster_url> [--bootstrap-servers=<broker_urls>] [--offset-topic=<offset_topic>] [--admin-client-config=<config_string>]. ",
+                    e);
         }
     }
 }

--- a/src/main/java/org/moditect/kcctl/util/Strings.java
+++ b/src/main/java/org/moditect/kcctl/util/Strings.java
@@ -15,6 +15,10 @@
  */
 package org.moditect.kcctl.util;
 
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Properties;
+
 public class Strings {
 
     private Strings() {
@@ -26,5 +30,22 @@ public class Strings {
         }
 
         return string.trim().isEmpty();
+    }
+
+    public static Properties toProperties(String string) throws IOException {
+        // Thanks to https://stackoverflow.com/a/58481108
+        // for the pattern here
+        final String formattedString = string.trim().replace(",", System.lineSeparator());
+        final StringReader stringReader = new StringReader(formattedString);
+        try {
+            final Properties properties = new Properties();
+            properties.load(stringReader);
+            return properties;
+        }
+        finally {
+            if (stringReader != null) {
+                stringReader.close();
+            }
+        }
     }
 }

--- a/src/test/java/org/moditect/kcctl/util/ConfigurationContextTest.java
+++ b/src/test/java/org/moditect/kcctl/util/ConfigurationContextTest.java
@@ -145,7 +145,7 @@ class ConfigurationContextTest {
     @Nested
     class GetclientConfig {
         @Test
-        void should_return_a_map_of_the_admin_client_config() throws IOException {
+        void should_return_a_map_of_the_client_config() throws IOException {
             var configFile = tempDir.toPath().resolve(".kcctl");
 
             Files.writeString(configFile,
@@ -160,7 +160,7 @@ class ConfigurationContextTest {
         }
 
         @Test
-        void should_return_an_empty_map_of_the_admin_client_config() throws IOException {
+        void should_return_an_empty_map_of_the_client_config() throws IOException {
             var configFile = tempDir.toPath().resolve(".kcctl");
 
             Files.writeString(configFile,
@@ -170,7 +170,7 @@ class ConfigurationContextTest {
         }
 
         @Test
-        void should_return_a_null_map_of_the_admin_client_config() throws IOException {
+        void should_return_a_null_map_of_the_client_config() throws IOException {
             var configFile = tempDir.toPath().resolve(".kcctl");
 
             Files.writeString(configFile,
@@ -180,7 +180,7 @@ class ConfigurationContextTest {
         }
 
         @Test
-        void should_return_a_null_map_of_the_admin_client_config_when_missing() throws IOException {
+        void should_return_a_null_map_of_the_client_config_when_missing() throws IOException {
             var configFile = tempDir.toPath().resolve(".kcctl");
 
             Files.writeString(configFile,

--- a/src/test/java/org/moditect/kcctl/util/ConfigurationContextTest.java
+++ b/src/test/java/org/moditect/kcctl/util/ConfigurationContextTest.java
@@ -143,14 +143,14 @@ class ConfigurationContextTest {
     }
 
     @Nested
-    class GetAdminClientConfig {
+    class GetclientConfig {
         @Test
         void should_return_a_map_of_the_admin_client_config() throws IOException {
             var configFile = tempDir.toPath().resolve(".kcctl");
 
             Files.writeString(configFile,
-                    "{ \"currentContext\": \"preprod\", \"preprod\": { \"cluster\": \"http://preprod:8083\", \"password\": \"p@ssword\", \"adminClientConfig\": { \"sasl.username\": \"myuser\", \"sasl.password\": \"mypassword\" } }}");
-            assertThat(new ConfigurationContext(tempDir).getCurrentContext().getAdminClientConfig())
+                    "{ \"currentContext\": \"preprod\", \"preprod\": { \"cluster\": \"http://preprod:8083\", \"password\": \"p@ssword\", \"clientConfig\": { \"sasl.username\": \"myuser\", \"sasl.password\": \"mypassword\" } }}");
+            assertThat(new ConfigurationContext(tempDir).getCurrentContext().getClientConfig())
                     .isEqualTo(new HashMap<String, Object>() {
                         {
                             this.put("sasl.password", "mypassword");
@@ -164,8 +164,8 @@ class ConfigurationContextTest {
             var configFile = tempDir.toPath().resolve(".kcctl");
 
             Files.writeString(configFile,
-                    "{ \"currentContext\": \"preprod\", \"preprod\": { \"cluster\": \"http://preprod:8083\", \"password\": \"p@ssword\", \"adminClientConfig\": { } }}");
-            assertThat(new ConfigurationContext(tempDir).getCurrentContext().getAdminClientConfig())
+                    "{ \"currentContext\": \"preprod\", \"preprod\": { \"cluster\": \"http://preprod:8083\", \"password\": \"p@ssword\", \"clientConfig\": { } }}");
+            assertThat(new ConfigurationContext(tempDir).getCurrentContext().getClientConfig())
                     .isEqualTo(new HashMap<String, Object>());
         }
 
@@ -174,8 +174,8 @@ class ConfigurationContextTest {
             var configFile = tempDir.toPath().resolve(".kcctl");
 
             Files.writeString(configFile,
-                    "{ \"currentContext\": \"preprod\", \"preprod\": { \"cluster\": \"http://preprod:8083\", \"password\": \"p@ssword\", \"adminClientConfig\": null }}");
-            assertThat(new ConfigurationContext(tempDir).getCurrentContext().getAdminClientConfig())
+                    "{ \"currentContext\": \"preprod\", \"preprod\": { \"cluster\": \"http://preprod:8083\", \"password\": \"p@ssword\", \"clientConfig\": null }}");
+            assertThat(new ConfigurationContext(tempDir).getCurrentContext().getClientConfig())
                     .isNull();
         }
 
@@ -185,9 +185,9 @@ class ConfigurationContextTest {
 
             Files.writeString(configFile,
                     "{ \"currentContext\": \"preprod\", \"preprod\": { \"cluster\": \"http://preprod:8083\", \"password\": \"p@ssword\" }}");
-            assertThat(new ConfigurationContext(tempDir).getCurrentContext().getAdminClientConfig())
+            assertThat(new ConfigurationContext(tempDir).getCurrentContext().getClientConfig())
                     .isNull();
-        }        
+        }
     }
 
     static Stream<Arguments> setConfigurationArguments() {

--- a/src/test/java/org/moditect/kcctl/util/StringsTest.java
+++ b/src/test/java/org/moditect/kcctl/util/StringsTest.java
@@ -15,35 +15,89 @@
  */
 package org.moditect.kcctl.util;
 
+import java.io.IOException;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StringsTest {
 
-    @Test
-    public void nullIsBlank() {
-        assertTrue(Strings.isBlank(null));
+    @Nested
+    public class IsBlank {
+        @Test
+        public void nullIsBlank() {
+            assertTrue(Strings.isBlank(null));
+        }
+
+        @Test
+        public void emptyIsBlank() {
+            assertTrue(Strings.isBlank(""));
+        }
+
+        @Test
+        public void whitespaceIsBlank() {
+            assertTrue(Strings.isBlank(" "));
+        }
+
+        @Test
+        public void bobIsNotBlank() {
+            assertFalse(Strings.isBlank("bob"));
+        }
+
+        @Test
+        public void bobWithWhitespaceIsNotBlank() {
+            assertFalse(Strings.isBlank("  bob  "));
+        }
     }
 
-    @Test
-    public void emptyIsBlank() {
-        assertTrue(Strings.isBlank(""));
-    }
+    @Nested
+    public class ToProperties {
+        @Test
+        public void singlePropertyLoadProperly() throws IOException {
+            final Properties props = Strings.toProperties("this.is.a.property=true");
+            assertEquals(props.getProperty("this.is.a.property"), "true");
+        }
 
-    @Test
-    public void whitespaceIsBlank() {
-        assertTrue(Strings.isBlank(" "));
-    }
+        @Test
+        public void multiplePropertiesLoadProperly() throws IOException {
+            final Properties props = Strings.toProperties("this.is.a.property=true,this.is.another.one=hello");
 
-    @Test
-    public void bobIsNotBlank() {
-        assertFalse(Strings.isBlank("bob"));
-    }
+            assertEquals("true", props.getProperty("this.is.a.property"));
+            assertEquals("hello", props.getProperty("this.is.another.one"));
+        }
 
-    @Test
-    public void bobWithWhitespaceIsNotBlank() {
-        assertFalse(Strings.isBlank("  bob  "));
+        @Test
+        public void whitespaceAroundPropertiesLoadProperly() throws IOException {
+            final Properties props = Strings.toProperties("      this.is.a.property=true, this.is.another.one=hello   ");
+
+            assertEquals("true", props.getProperty("this.is.a.property"));
+            assertEquals("hello", props.getProperty("this.is.another.one"));
+        }
+
+        @Test
+        public void noPropertiesInStringIsEmpty() throws IOException {
+            final Properties props = Strings.toProperties("");
+
+            assertEquals(true, props.isEmpty());
+        }
+
+        @Test
+        public void commaOnlyStringIsEmpty() throws IOException {
+            final Properties props = Strings.toProperties(",");
+
+            assertEquals(true, props.isEmpty());
+        }
+
+        @Test
+        public void multipleCommasOnlyStringIsEmpty() throws IOException {
+            final Properties props = Strings.toProperties(",,");
+
+            assertEquals(true, props.isEmpty());
+        }
     }
 }


### PR DESCRIPTION
With this PR, kafka client configuration will not be stored with the context in .kcctl via kcctl config

The following is what the new config set-context usage would be:

```
Usage: kcctl config set-context [--bootstrap-servers=<bootstrapServers>]
                                [--cluster=<cluster>] [-f=<clientConfigFile>]
                                [--offset-topic=<offsetTopic>]
                                [--password=<password>] [--username=<username>]
                                [-o=<clientConfigs>]... <contextName>
Configures the specified context with the provided arguments
      <contextName>         Context name
      --bootstrap-servers=<bootstrapServers>
                            Comma-separated list of Kafka broker URLs
      --cluster=<cluster>   URL of the Kafka Connect cluster to connect to
  -f, --client-config-file=<clientConfigFile>
                            Configuration file for client
  -o, --client-config=<clientConfigs>
                            Configuration for client
      --offset-topic=<offsetTopic>
                            Name of the offset topic
      --password=<password> Password for basic authentication
      --username=<username> Username for basic authentication
```

Note the new options:

```
  -f, --client-config-file=<clientConfigFile>
                            Configuration file for client
  -o, --client-config=<clientConfigs>
                            Configuration for client
```

For this, you may pass in a -f/--client-config-file parameter to pass in a properties file, or the -o/--client-config which is a comma delimited list of configs (I chose -o as I figured -c and -s would likely be for cluster and bootstrap server at some point).  The --client-config flag may be passed multiple times, i.e. `--client-config="sasl.username=myuser" --client-config="sasl.password=mypassword"`.

--client-config values will override and values passed via --client-config-files, and --client-config values that appear later in the command will override prior values. 

Note: I didn't put this in the README.md yet as I'd like some clarification on the best way to document all that behavior. Also, there's no feature that actually uses this yet, so documentation may just be confusing at this point.  Thoughts? @gunnarmorling 
