### PR TITLE
feat: follow redirects when calling Kafka Connect API

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,3 +16,5 @@
 
 quarkus.banner.enabled=false
 %prod.quarkus.log.level=ERROR
+
+org.kcctl.service.KafkaConnectApi/mp-rest/followRedirects=true


### PR DESCRIPTION
 When calling the Kafka Connect API behind a proxy i get this error :
```
kkcctl info
javax.ws.rs.RedirectionException: HTTP 302 Found
	at org.jboss.resteasy.client.jaxrs.internal.ClientInvocation.extractResult(ClientInvocation.java:237)
	at org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.BodyEntityExtractor.extractEntity(BodyEntityExtractor.java:64)
	at org.jboss.resteasy.client.jaxrs.internal.proxy.ClientInvoker.invokeSync(ClientInvoker.java:154)
	at org.jboss.resteasy.client.jaxrs.internal.proxy.ClientInvoker.invoke(ClientInvoker.java:115)
	at org.jboss.resteasy.client.jaxrs.internal.proxy.ClientProxy.invoke(ClientProxy.java:76)
	at jdk.proxy4.$Proxy220.getWorkerInfo(Unknown Source)
	at java.lang.reflect.Method.invoke(Method.java:568)
	at org.jboss.resteasy.microprofile.client.ProxyInvocationHandler.invoke(ProxyInvocationHandler.java:146)
	at jdk.proxy4.$Proxy221.getWorkerInfo(Unknown Source)
	at org.kcctl.command.InfoCommand.run(InfoCommand.java:39)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1939)
	at picocli.CommandLine.access$1300(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2358)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2352)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2314)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2179)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2316)
	at io.quarkus.picocli.runtime.PicocliRunner$EventExecutionStrategy.execute(PicocliRunner.java:26)
	at picocli.CommandLine.execute(CommandLine.java:2078)
	at io.quarkus.picocli.runtime.PicocliRunner.run(PicocliRunner.java:40)
	at io.quarkus.runtime.ApplicationLifecycleManager.run(ApplicationLifecycleManager.java:125)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:67)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:41)
	at io.quarkus.runner.GeneratedMain.main(GeneratedMain.zig:30)
```
