### PR TITLE
🚀 feat(apply): add parametric json configuration support

### DIFF
--- a/src/test/resources/local-file-source-parameters.json
+++ b/src/test/resources/local-file-source-parameters.json
@@ -1,0 +1,10 @@
+{
+    "name": "local-file-source-parameters",
+    "config": {
+        "connector.class": "FileStreamSource",
+		"tasks.max": 1,
+        "topic": "$#1",
+        "file": "$#2",
+        "dbpassword": "$#3"
+    }
+}


### PR DESCRIPTION
As a developer: I don't want to put my connector configs in the company repository with database passwords or sensitive data.

Description: Pass parameters to config for sensitive data when creating and updating the connector.

I add a new argument `--config-parameters` to `apply` command.

Let's say we have a connector config like the below. If I put this configuration in the repository, this does not allow for security. I can set sensitive parts to blank for the repository but if I put this configuration to pipeline or automation for generic configuration that will not work I must create many same configuration file just for one field and this is not cool.
```json
{
  "name": "my-connector",
  "config": {
    "connector.class": "io.debezium.connector.mysql.MySqlConnector",
    "database.user": "debezium-user",
    "database.password": "password",
    ...
  }
}
```

So, I can put parameters to these fields and I can set them from the command line
```json
{
  "name": "my-connector",
  "config": {
    "connector.class": "io.debezium.connector.mysql.MySqlConnector",
    "database.user": "$#1",
    "database.password": "$#2",
    ...
  }
}
```

And I can run this command;
```sh
kcctl apply -f test-connector.json -ca "debezium-user password"
```

Or I can use for duplicate fields
```json
{
  ...
  "key.converter": "io.confluent.connect.avro.AvroConverter",
  "key.converter.schema.registry.url": "$#1",
  "value.converter": "io.confluent.connect.avro.AvroConverter",
  "value.converter.schema.registry.url": "$#1"
  ...
}
```