### PR TITLE
⤴️ Fixes for Connect 3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>2.10.1.Final</quarkus.platform.version>
+    <debezium.version>1.9.5.Final</debezium.version>
     <artifactsDir>target</artifactsDir>
   </properties>
 
@@ -110,7 +111,7 @@
     <dependency>
       <groupId>io.debezium</groupId>
       <artifactId>debezium-testing-testcontainers</artifactId>
-      <version>1.9.4.Final</version>
+      <version>${debezium.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/kcctl/command/ApplyCommandTest.java
+++ b/src/test/java/org/kcctl/command/ApplyCommandTest.java
@@ -46,53 +46,53 @@ class ApplyCommandTest extends IntegrationTest {
 
     @Test
     public void should_create_two_connectors() {
-        var path = Paths.get("src", "test", "resources", "local-file-source.json");
-        var path2 = Paths.get("src", "test", "resources", "local-file-source-2.json");
+        var path = Paths.get("src", "test", "resources", "heartbeat-source.json");
+        var path2 = Paths.get("src", "test", "resources", "heartbeat-source-2.json");
         int exitCode = context.commandLine().execute("-f", path.toAbsolutePath().toString(), "-f", path2.toAbsolutePath().toString());
         assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
-        assertThat(context.output().toString()).contains("Created connector local-file-source", "Created connector local-file-source-2");
+        assertThat(context.output().toString()).contains("Created connector heartbeat-source", "Created connector heartbeat-source-2");
 
-        kafkaConnect.ensureConnectorRegistered("local-file-source");
-        kafkaConnect.ensureConnectorRegistered("local-file-source-2");
-        kafkaConnect.ensureConnectorState("local-file-source", Connector.State.RUNNING);
-        kafkaConnect.ensureConnectorState("local-file-source-2", Connector.State.RUNNING);
-        kafkaConnect.ensureConnectorTaskState("local-file-source", 0, Connector.State.RUNNING);
-        kafkaConnect.ensureConnectorTaskState("local-file-source-2", 0, Connector.State.RUNNING);
+        kafkaConnect.ensureConnectorRegistered("heartbeat-source");
+        kafkaConnect.ensureConnectorRegistered("heartbeat-source-2");
+        kafkaConnect.ensureConnectorState("heartbeat-source", Connector.State.RUNNING);
+        kafkaConnect.ensureConnectorState("heartbeat-source-2", Connector.State.RUNNING);
+        kafkaConnect.ensureConnectorTaskState("heartbeat-source", 0, Connector.State.RUNNING);
+        kafkaConnect.ensureConnectorTaskState("heartbeat-source-2", 0, Connector.State.RUNNING);
     }
 
     @Test
     public void should_create_connector_from_stdin() throws IOException {
-        var path = Paths.get("src", "test", "resources", "local-file-source.json");
+        var path = Paths.get("src", "test", "resources", "heartbeat-source.json");
         InputStream fakeIn = new ByteArrayInputStream(Files.readAllBytes(path));
         System.setIn(fakeIn);
 
         int exitCode = context.commandLine().execute("-f", "-");
         assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
-        assertThat(context.output().toString().trim()).isEqualTo("Created connector local-file-source");
+        assertThat(context.output().toString().trim()).isEqualTo("Created connector heartbeat-source");
 
-        kafkaConnect.ensureConnectorRegistered("local-file-source");
-        kafkaConnect.ensureConnectorState("local-file-source", Connector.State.RUNNING);
-        kafkaConnect.ensureConnectorTaskState("local-file-source", 0, Connector.State.RUNNING);
+        kafkaConnect.ensureConnectorRegistered("heartbeat-source");
+        kafkaConnect.ensureConnectorState("heartbeat-source", Connector.State.RUNNING);
+        kafkaConnect.ensureConnectorTaskState("heartbeat-source", 0, Connector.State.RUNNING);
     }
 
     @Test
     public void should_update_connector() {
-        var path = Paths.get("src", "test", "resources", "local-file-source.json");
+        var path = Paths.get("src", "test", "resources", "heartbeat-source.json");
         int exitCode = context.commandLine().execute("-f", path.toAbsolutePath().toString());
         assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
-        assertThat(context.output().toString().trim()).isEqualTo("Created connector local-file-source");
+        assertThat(context.output().toString().trim()).isEqualTo("Created connector heartbeat-source");
 
-        path = Paths.get("src", "test", "resources", "local-file-source-update.json");
+        path = Paths.get("src", "test", "resources", "heartbeat-source-update.json");
         exitCode = context.commandLine().execute("-f", path.toAbsolutePath().toString());
         assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
         assertThat(context.output().toString()).isEqualTo("""
-                Created connector local-file-source
-                Updated connector local-file-source
+                Created connector heartbeat-source
+                Updated connector heartbeat-source
                 """);
 
-        kafkaConnect.ensureConnectorRegistered("local-file-source");
-        kafkaConnect.ensureConnectorState("local-file-source", Connector.State.RUNNING);
-        kafkaConnect.ensureConnectorTaskState("local-file-source", 0, Connector.State.RUNNING);
+        kafkaConnect.ensureConnectorRegistered("heartbeat-source");
+        kafkaConnect.ensureConnectorState("heartbeat-source", Connector.State.RUNNING);
+        kafkaConnect.ensureConnectorTaskState("heartbeat-source", 0, Connector.State.RUNNING);
     }
 
     @Test
@@ -103,7 +103,7 @@ class ApplyCommandTest extends IntegrationTest {
 
     @Test
     public void dont_apply_if_files_wrong() {
-        var path = Paths.get("src", "test", "resources", "local-file-source.json");
+        var path = Paths.get("src", "test", "resources", "heartbeat-source.json");
         var wrongPath = Paths.get("src", "test", "resources", "dont_exists.json");
 
         int exitCode = context.commandLine().execute("-f", path.toAbsolutePath().toString(), "-f", wrongPath.toAbsolutePath().toString());
@@ -114,8 +114,8 @@ class ApplyCommandTest extends IntegrationTest {
 
     @Test
     public void fail_on_first_error() {
-        var pathBad = Paths.get("src", "test", "resources", "local-file-source-bad.json");
-        var path = Paths.get("src", "test", "resources", "local-file-source.json");
+        var pathBad = Paths.get("src", "test", "resources", "heartbeat-source-bad.json");
+        var path = Paths.get("src", "test", "resources", "heartbeat-source.json");
 
         int exitCode = context.commandLine().execute("-f", pathBad.toAbsolutePath().toString(), "-f", path.toAbsolutePath().toString());
 

--- a/src/test/java/org/kcctl/command/DescribeConnectorCommandTest.java
+++ b/src/test/java/org/kcctl/command/DescribeConnectorCommandTest.java
@@ -54,6 +54,6 @@ class DescribeConnectorCommandTest extends IntegrationTest {
         System.setOut(old);
 
         assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
-        assertThat(baos.toString()).contains("local-file-source-test");
+        assertThat(baos.toString()).contains(HEARTBEAT_TOPIC);
     }
 }

--- a/src/test/java/org/kcctl/command/GetPluginsCommandTest.java
+++ b/src/test/java/org/kcctl/command/GetPluginsCommandTest.java
@@ -39,8 +39,9 @@ class GetPluginsCommandTest extends IntegrationTest {
     KcctlCommandContext<GetPluginsCommand> context;
 
     @Test
-    public void should_print_info() {
+    public void should_print_info() throws Exception {
         String debeziumVersion = ContainerImageVersions.getStableVersion("debezium/connect");
+        String kafkaVersion = getConnectVersion();
 
         int exitCode = context.commandLine().execute();
         assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
@@ -55,10 +56,8 @@ class GetPluginsCommandTest extends IntegrationTest {
                         "source   io.debezium.connector.postgresql.PostgresConnector          " + debeziumVersion,
                         "source   io.debezium.connector.sqlserver.SqlServerConnector          " + debeziumVersion,
                         "source   io.debezium.connector.vitess.VitessConnector                " + debeziumVersion,
-                        "source   org.apache.kafka.connect.file.FileStreamSourceConnector     3.1.0",
-                        "source   org.apache.kafka.connect.mirror.MirrorCheckpointConnector   1",
-                        "source   org.apache.kafka.connect.mirror.MirrorHeartbeatConnector    1",
-                        "source   org.apache.kafka.connect.mirror.MirrorSourceConnector       1",
-                        "sink     org.apache.kafka.connect.file.FileStreamSinkConnector       3.1.0");
+                        "source   org.apache.kafka.connect.mirror.MirrorCheckpointConnector   " + kafkaVersion,
+                        "source   org.apache.kafka.connect.mirror.MirrorHeartbeatConnector    " + kafkaVersion,
+                        "source   org.apache.kafka.connect.mirror.MirrorSourceConnector       " + kafkaVersion);
     }
 }

--- a/src/test/java/org/kcctl/command/InfoCommandTest.java
+++ b/src/test/java/org/kcctl/command/InfoCommandTest.java
@@ -38,14 +38,13 @@ class InfoCommandTest extends IntegrationTest {
     KcctlCommandContext<InfoCommand> context;
 
     @Test
-    public void should_print_info() {
+    public void should_print_info() throws Exception {
         int exitCode = context.commandLine().execute();
         assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
-        assertThat(context.output().toString().trim().lines())
-                .map(String::trim)
-                .contains(
-                        "URL:               " + kafkaConnect.getTarget(),
-                        "Version:           3.1.0",
-                        "Commit:            37edeed0777bacb3");
+        assertThat(context.output().toString().trim())
+                .matches("URL:\\s+" + kafkaConnect.getTarget() + "\\n" +
+                        "Version:\\s+" + getConnectVersion() + "\\n" +
+                        "Commit:\\s+[\\dabcdef]{16}\\n" +
+                        "Kafka Cluster ID:\\s+[\\w-]{22}");
     }
 }

--- a/src/test/java/org/kcctl/command/PatchCommandTest.java
+++ b/src/test/java/org/kcctl/command/PatchCommandTest.java
@@ -53,6 +53,6 @@ class PatchCommandTest extends IntegrationTest {
         System.setOut(old);
 
         assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
-        assertThat(baos.toString()).contains("test:             true");
+        assertThat(baos.toString()).contains("test:                  true");
     }
 }

--- a/src/test/resources/heartbeat-source-2.json
+++ b/src/test/resources/heartbeat-source-2.json
@@ -1,0 +1,9 @@
+{
+	"name": "heartbeat-source-2",
+	"config": {
+		"connector.class": "org.apache.kafka.connect.mirror.MirrorHeartbeatConnector",
+		"tasks.max": 1,
+		"topic": "heartbeat-test-2",
+		"source.cluster.alias": "source"
+	}
+}

--- a/src/test/resources/heartbeat-source-bad.json
+++ b/src/test/resources/heartbeat-source-bad.json
@@ -1,0 +1,5 @@
+{
+	"name": "heartbeat-source-bad",
+	"config": {
+	}
+}

--- a/src/test/resources/heartbeat-source-update.json
+++ b/src/test/resources/heartbeat-source-update.json
@@ -1,0 +1,9 @@
+{
+	"name": "heartbeat-source",
+	"config": {
+		"connector.class": "org.apache.kafka.connect.mirror.MirrorHeartbeatConnector",
+		"tasks.max": 1,
+		"topic": "heartbeat-test-2",
+		"source.cluster.alias": "source"
+	}
+}

--- a/src/test/resources/heartbeat-source.json
+++ b/src/test/resources/heartbeat-source.json
@@ -1,0 +1,9 @@
+{
+	"name": "heartbeat-source",
+	"config": {
+		"connector.class": "org.apache.kafka.connect.mirror.MirrorHeartbeatConnector",
+		"tasks.max": 1,
+		"topic": "heartbeat-test",
+		"source.cluster.alias": "source"
+	}
+}

--- a/src/test/resources/local-file-source-2.json
+++ b/src/test/resources/local-file-source-2.json
@@ -1,9 +1,0 @@
-{
-	"name": "local-file-source-2",
-	"config": {
-		"connector.class": "FileStreamSource",
-		"tasks.max": 1,
-		"file": "/tmp/test-2",
-		"topic": "local-file-source-test-2"
-	}
-}

--- a/src/test/resources/local-file-source-bad.json
+++ b/src/test/resources/local-file-source-bad.json
@@ -1,5 +1,0 @@
-{
-	"name": "local-file-source-bad",
-	"config": {
-	}
-}

--- a/src/test/resources/local-file-source-update.json
+++ b/src/test/resources/local-file-source-update.json
@@ -1,9 +1,0 @@
-{
-	"name": "local-file-source",
-	"config": {
-		"connector.class": "FileStreamSource",
-		"tasks.max": 1,
-		"file": "/tmp/test",
-		"topic": "local-file-source-test-2"
-	}
-}

--- a/src/test/resources/local-file-source.json
+++ b/src/test/resources/local-file-source.json
@@ -1,9 +1,0 @@
-{
-	"name": "local-file-source",
-	"config": {
-		"connector.class": "FileStreamSource",
-		"tasks.max": 1,
-		"file": "/tmp/test",
-		"topic": "local-file-source-test"
-	}
-}


### PR DESCRIPTION
Debezium 1.9.5 switched to Kafka Connect 3.2.0. In that version, the `FileStream` connectors have been removed from the classpath, because of [KAFKA-13748](https://issues.apache.org/jira/browse/KAFKA-13748).

Kcctl integration tests automatically pick the latest Debezium so some of the tests that rely on `FileStreamSource` are not working anymore.

To address this issue, I decided to update the integration tests to instead use `MirrorHeartbeatConnector`.

Another alternative would be to update `debezium/connect` to optionally re-enable the `FileStream` connectors. Since this is only fixing tests and this has some security implications I decided to not follow this approach. If you think this would be preferable I can make the changes.