### PR TITLE
#261 Add search filter API for plugin descriptions

### DIFF
--- a/kcctl_completion
+++ b/kcctl_completion
@@ -681,10 +681,25 @@ function _picocli_kcctl_describe_connectors() {
 function _picocli_kcctl_describe_plugin() {
   # Get completion data
   local curr_word=${COMP_WORDS[COMP_CWORD]}
+  local prev_word=${COMP_WORDS[COMP_CWORD-1]}
 
   local commands=""
   local flag_opts=""
-  local arg_opts=""
+  local arg_opts="--search --search-name --search-description"
+
+  type compopt &>/dev/null && compopt +o default
+
+  case ${prev_word} in
+    --search)
+      return
+      ;;
+    --search-name)
+      return
+      ;;
+    --search-description)
+      return
+      ;;
+  esac
   local PLUGIN_NAME_pos_param_args=`kcctl plugin-name-completions` # 0-0 values
 
   if [[ "${curr_word}" == -* ]]; then

--- a/src/main/java/org/kcctl/command/DescribePluginCommand.java
+++ b/src/main/java/org/kcctl/command/DescribePluginCommand.java
@@ -41,11 +41,11 @@ import static org.kcctl.util.Colors.ANSI_WHITE_BOLD;
 public class DescribePluginCommand implements Callable<Integer> {
 
     static class ConfigSearch {
-        @CommandLine.Option(names = "--search", description = "Filter results to only properties whose name or docstring matches a given regex")
+        @CommandLine.Option(names = "--search", description = "Filter results to only properties whose name or docstring matches a given regex, using Java pattern syntax. Prefix with (?i) for case-insensitive searches")
         Pattern search;
-        @CommandLine.Option(names = "--search-name", description = "Filter results to only properties whose name matches a given regex")
+        @CommandLine.Option(names = "--search-name", description = "Filter results to only properties whose name matches a given regex, using Java pattern syntax. Prefix with (?i) for case-insensitive searches")
         Pattern searchName;
-        @CommandLine.Option(names = "--search-description", description = "Filter results to only properties whose docstring matches a given regex")
+        @CommandLine.Option(names = "--search-description", description = "Filter results to only properties whose docstring matches a given regex, using Java pattern syntax. Prefix with (?i) for case-insensitive searches")
         Pattern searchDescription;
 
         public List<ConfigInfos.ConfigKeyInfo> filterResults(List<ConfigInfos.ConfigKeyInfo> configs) {
@@ -60,8 +60,8 @@ public class DescribePluginCommand implements Callable<Integer> {
             }
             else {
                 // The if/else if branches here should be exhaustive; if for some reason picocli populates
-                // the configSearch field but none of its members, we degrade gracefully here by not performing
-                // any filtering of config results
+                // an instance of this class but none of its members, we degrade gracefully here by not
+                // performing any filtering of config results
                 return configs;
             }
         }

--- a/src/main/java/org/kcctl/command/DescribePluginCommand.java
+++ b/src/main/java/org/kcctl/command/DescribePluginCommand.java
@@ -18,6 +18,7 @@ package org.kcctl.command;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.regex.Pattern;
 
 import javax.inject.Inject;
 
@@ -26,6 +27,7 @@ import org.kcctl.completion.PluginNameCompletions;
 import org.kcctl.service.ConfigInfos;
 import org.kcctl.service.KafkaConnectApi;
 import org.kcctl.util.ConfigurationContext;
+import org.kcctl.util.Search;
 import org.kcctl.util.Tuple;
 import org.kcctl.util.Version;
 
@@ -38,8 +40,38 @@ import static org.kcctl.util.Colors.ANSI_WHITE_BOLD;
 @Command(name = "plugin", description = "Displays information about given plugin")
 public class DescribePluginCommand implements Callable<Integer> {
 
+    static class ConfigSearch {
+        @CommandLine.Option(names = "--search", description = "Filter results to only properties whose name or docstring matches a given regex")
+        Pattern search;
+        @CommandLine.Option(names = "--search-name", description = "Filter results to only properties whose name matches a given regex")
+        Pattern searchName;
+        @CommandLine.Option(names = "--search-description", description = "Filter results to only properties whose docstring matches a given regex")
+        Pattern searchDescription;
+
+        public List<ConfigInfos.ConfigKeyInfo> filterResults(List<ConfigInfos.ConfigKeyInfo> configs) {
+            if (search != null) {
+                return Search.searchConfig(configs, search);
+            }
+            else if (searchName != null) {
+                return Search.searchConfigByName(configs, searchName);
+            }
+            else if (searchDescription != null) {
+                return Search.searchConfigByDescription(configs, searchDescription);
+            }
+            else {
+                // The if/else if branches here should be exhaustive; if for some reason picocli populates
+                // the configSearch field but none of its members, we degrade gracefully here by not performing
+                // any filtering of config results
+                return configs;
+            }
+        }
+    }
+
     @CommandLine.Spec
     CommandLine.Model.CommandSpec spec;
+
+    @CommandLine.ArgGroup(exclusive = true)
+    ConfigSearch configSearch;
 
     @CommandLine.Parameters(paramLabel = "PLUGIN NAME", description = "Name of the plugin", completionCandidates = PluginNameCompletions.class)
     String name;
@@ -73,6 +105,9 @@ public class DescribePluginCommand implements Callable<Integer> {
 
         List<ConfigInfos.ConfigKeyInfo> configs = kafkaConnectApi.getConnectorPluginConfig(name);
         System.out.println();
+        if (configSearch != null) {
+            configs = configSearch.filterResults(configs);
+        }
         for (ConfigInfos.ConfigKeyInfo config : configs) {
             Tuple.print(Arrays.asList(
                     new Tuple(ANSI_WHITE_BOLD + "Name" + ANSI_RESET, config.name()),

--- a/src/main/java/org/kcctl/util/Colors.java
+++ b/src/main/java/org/kcctl/util/Colors.java
@@ -17,20 +17,28 @@ package org.kcctl.util;
 
 public class Colors {
 
-    public static final String ANSI_RESET = "\u001B[0m";
-    public static final String ANSI_BLACK = "\u001B[30m";
-    public static final String ANSI_RED = "\u001B[31m";
-    public static final String ANSI_GREEN = "\u001B[32m";
-    public static final String ANSI_YELLOW = "\u001B[33m";
-    public static final String ANSI_BLUE = "\u001B[34m";
-    public static final String ANSI_PURPLE = "\u001B[35m";
-    public static final String ANSI_CYAN = "\u001B[36m";
-    public static final String ANSI_WHITE = "\u001B[37m";
-    public static final String ANSI_WHITE_BOLD = "\u001B[37;1m";
+    // ANSI escape sequence
+    private static final String E = "\u001B[";
 
-    public static final String ANSI_UNDERLINE = "\u001B[4m";
+    public static final String ANSI_RESET = E + "0m";
+    public static final String ANSI_BLACK = E + "30m";
+    public static final String ANSI_RED = E + "31m";
+    public static final String ANSI_GREEN = E + "32m";
+    public static final String ANSI_YELLOW = E + "33m";
+    public static final String ANSI_BLUE = E + "34m";
+    public static final String ANSI_PURPLE = E + "35m";
+    public static final String ANSI_CYAN = E + "36m";
+    public static final String ANSI_WHITE = E + "37m";
+    public static final String ANSI_WHITE_BOLD = E + "37;1m";
+    public static final String ANSI_BOLD = E + "1m";
+    public static final String ANSI_WHITE_BACKGROUND = E + "107m";
 
-    public static String underline(String input) {
-        return ANSI_UNDERLINE + input + ANSI_RESET;
+    /**
+     * Highlight some text with bold, black font and a white background
+     * @param input the text to highlight; if null, the literal "null" is used in its place
+     * @return the highlighted text; never null
+     */
+    public static String highlight(String input) {
+        return ANSI_WHITE_BACKGROUND + ANSI_BLACK + ANSI_BOLD + input + ANSI_RESET;
     }
 }

--- a/src/main/java/org/kcctl/util/Colors.java
+++ b/src/main/java/org/kcctl/util/Colors.java
@@ -27,4 +27,10 @@ public class Colors {
     public static final String ANSI_CYAN = "\u001B[36m";
     public static final String ANSI_WHITE = "\u001B[37m";
     public static final String ANSI_WHITE_BOLD = "\u001B[37;1m";
+
+    public static final String ANSI_UNDERLINE = "\u001B[4m";
+
+    public static String underline(String input) {
+        return ANSI_UNDERLINE + input + ANSI_RESET;
+    }
 }

--- a/src/main/java/org/kcctl/util/MutableConfigKeyInfo.java
+++ b/src/main/java/org/kcctl/util/MutableConfigKeyInfo.java
@@ -1,0 +1,199 @@
+/*
+ *  Copyright 2021 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.kcctl.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static org.kcctl.service.ConfigInfos.ConfigKeyInfo;
+
+public class MutableConfigKeyInfo {
+
+    private String name;
+    private String type;
+    private boolean required;
+    private String defaultValue;
+    private String importance;
+    private String documentation;
+    private String group;
+    private int orderInGroup;
+    private String width;
+    private String displayName;
+    private List<String> dependents;
+
+    public MutableConfigKeyInfo(
+                                String name,
+                                String type,
+                                boolean required,
+                                String defaultValue,
+                                String importance,
+                                String documentation,
+                                String group,
+                                int orderInGroup,
+                                String width,
+                                String displayName,
+                                List<String> dependents) {
+        this.name = name;
+        this.type = type;
+        this.required = required;
+        this.defaultValue = defaultValue;
+        this.importance = importance;
+        this.documentation = documentation;
+        this.group = group;
+        this.orderInGroup = orderInGroup;
+        this.width = width;
+        this.displayName = displayName;
+        this.dependents = dependents;
+    }
+
+    public static MutableConfigKeyInfo fromRecord(ConfigKeyInfo configKeyInfo) {
+        return new MutableConfigKeyInfo(
+                configKeyInfo.name(),
+                configKeyInfo.type(),
+                configKeyInfo.required(),
+                configKeyInfo.defaultValue(),
+                configKeyInfo.importance(),
+                configKeyInfo.documentation(),
+                configKeyInfo.group(),
+                configKeyInfo.orderInGroup(),
+                configKeyInfo.width(),
+                configKeyInfo.displayName(),
+                configKeyInfo.dependents() != null ? new ArrayList<>(configKeyInfo.dependents()) : null);
+    }
+
+    public ConfigKeyInfo toRecord() {
+        return new ConfigKeyInfo(
+                name,
+                type,
+                required,
+                defaultValue,
+                importance,
+                documentation,
+                group,
+                orderInGroup,
+                width,
+                displayName,
+                dependents != null ? new ArrayList<>(dependents) : null);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+
+    public void setRequired(boolean required) {
+        this.required = required;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void setDefaultValue(String defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
+    public String getImportance() {
+        return importance;
+    }
+
+    public void setImportance(String importance) {
+        this.importance = importance;
+    }
+
+    public String getDocumentation() {
+        return documentation;
+    }
+
+    public void setDocumentation(String documentation) {
+        this.documentation = documentation;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public void setGroup(String group) {
+        this.group = group;
+    }
+
+    public int getOrderInGroup() {
+        return orderInGroup;
+    }
+
+    public void setOrderInGroup(int orderInGroup) {
+        this.orderInGroup = orderInGroup;
+    }
+
+    public String getWidth() {
+        return width;
+    }
+
+    public void setWidth(String width) {
+        this.width = width;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public List<String> getDependents() {
+        return dependents;
+    }
+
+    public void setDependents(List<String> dependents) {
+        this.dependents = dependents;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        MutableConfigKeyInfo that = (MutableConfigKeyInfo) o;
+        return required == that.required && orderInGroup == that.orderInGroup && Objects.equals(name, that.name) && Objects.equals(type, that.type)
+                && Objects.equals(defaultValue, that.defaultValue) && Objects.equals(importance, that.importance) && Objects.equals(documentation, that.documentation)
+                && Objects.equals(group, that.group) && Objects.equals(width, that.width) && Objects.equals(displayName, that.displayName)
+                && Objects.equals(dependents, that.dependents);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, type, required, defaultValue, importance, documentation, group, orderInGroup, width, displayName, dependents);
+    }
+
+}

--- a/src/main/java/org/kcctl/util/MutableConfigKeyInfo.java
+++ b/src/main/java/org/kcctl/util/MutableConfigKeyInfo.java
@@ -21,6 +21,13 @@ import java.util.Objects;
 
 import static org.kcctl.service.ConfigInfos.ConfigKeyInfo;
 
+/**
+ * This class has identical structure to the {@link ConfigKeyInfo} record, but with
+ * getters and setters that allow its content to be mutated after construction.
+ * <p>
+ * It can be used to manipulate data that was deserialized into a {@link ConfigKeyInfo}
+ * instance, without sacrificing the immutability of the {@link ConfigKeyInfo} record class.
+ */
 public class MutableConfigKeyInfo {
 
     private String name;
@@ -60,7 +67,14 @@ public class MutableConfigKeyInfo {
         this.dependents = dependents;
     }
 
+    /**
+     * Construct a matching {@link MutableConfigKeyInfo} instance from a {@link ConfigKeyInfo} record
+     * @param configKeyInfo the {@link ConfigKeyInfo} instance; may not be null
+     * @return a matching {@link MutableConfigKeyInfo} for the {@link ConfigKeyInfo} instance;
+     * never null
+     */
     public static MutableConfigKeyInfo fromRecord(ConfigKeyInfo configKeyInfo) {
+        Objects.requireNonNull(configKeyInfo, "configKeyInfo may not be null");
         return new MutableConfigKeyInfo(
                 configKeyInfo.name(),
                 configKeyInfo.type(),
@@ -75,6 +89,11 @@ public class MutableConfigKeyInfo {
                 configKeyInfo.dependents() != null ? new ArrayList<>(configKeyInfo.dependents()) : null);
     }
 
+    /**
+     * Convert this instance into an immutable {@link ConfigKeyInfo} record.
+     * @return a {@link ConfigKeyInfo} whose content matches that of this
+     * {@link MutableConfigKeyInfo} instance; never null
+     */
     public ConfigKeyInfo toRecord() {
         return new ConfigKeyInfo(
                 name,

--- a/src/main/java/org/kcctl/util/Search.java
+++ b/src/main/java/org/kcctl/util/Search.java
@@ -25,9 +25,22 @@ import java.util.regex.Pattern;
 
 import static org.kcctl.service.ConfigInfos.ConfigKeyInfo;
 
+/**
+ * Generic logic for filtering a collection of elements based on a regex match,
+ * with support for highlighting the matched portions of each element and examining
+ * multiple different terms (e.g., name and description) from each element.
+ */
 public class Search {
 
     // Generic records... I'm going to hell for this
+
+    /**
+     * A search term is a part of an element that can be checked against for a regex match while
+     * filtering search results, and modified in order to highlight the matching portions
+     * @param extractTerm used to extract the text to match against from the element
+     * @param setTerm used to override the text with a highlighted replacement if a match is found
+     * @param <E> the search element type
+     */
     public record SearchTerm<E>(Function<E, String> extractTerm, BiConsumer<E,String>setTerm)
     {
 
@@ -40,7 +53,8 @@ public class Search {
 
         String highlightedTerm = matcher.replaceAll(matchResult -> {
             String match = matchResult.group();
-            return match.isEmpty() ? "" : Colors.underline(matchResult.group());
+            // Sometimes regexes match empty strings; no point in highlighting those
+            return match.isEmpty() ? "" : Colors.highlight(matchResult.group());
         });
         setTerm.accept(element, highlightedTerm);
         return true;

--- a/src/main/java/org/kcctl/util/Search.java
+++ b/src/main/java/org/kcctl/util/Search.java
@@ -1,0 +1,116 @@
+/*
+ *  Copyright 2021 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.kcctl.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.kcctl.service.ConfigInfos.ConfigKeyInfo;
+
+public class Search {
+
+    // Generic records... I'm going to hell for this
+    public record SearchTerm<E>(Function<E, String> extractTerm, BiConsumer<E,String>setTerm)
+    {
+
+    public boolean matches(E element, Pattern regex) {
+        String term = extractTerm.apply(element);
+        Matcher matcher = regex.matcher(term);
+
+        if (!matcher.find())
+            return false;
+
+        String highlightedTerm = matcher.replaceAll(matchResult -> {
+            String match = matchResult.group();
+            return match.isEmpty() ? "" : Colors.underline(matchResult.group());
+        });
+        setTerm.accept(element, highlightedTerm);
+        return true;
+    }}
+
+    private static final SearchTerm<MutableConfigKeyInfo> CONFIG_NAME =
+            new SearchTerm<>(MutableConfigKeyInfo::getName, MutableConfigKeyInfo::setName);
+    private static final SearchTerm<MutableConfigKeyInfo> CONFIG_DESCRIPTION =
+            new SearchTerm<>(MutableConfigKeyInfo::getDocumentation, MutableConfigKeyInfo::setDocumentation);
+
+    /**
+     * Find the {@link ConfigKeyInfo config properties} that match a given regular expression, using
+     * all available terms.
+     * @param config the configuration properties to search; may not be null, but may be empty
+     * @param regex the regular expression to search for; may not be null
+     * @return the configuration properties whose {@link ConfigKeyInfo#name() name}
+     * or {@link ConfigKeyInfo#documentation() docstring} matches the regular expression. The order of the resulting
+     * list will match the iteration order of the provided {@link Collection}
+     */
+    public static List<ConfigKeyInfo> searchConfig(Collection<ConfigKeyInfo> config, Pattern regex) {
+        return searchConfig(config, regex, CONFIG_NAME, CONFIG_DESCRIPTION);
+    }
+
+    /**
+     * Find the {@link ConfigKeyInfo config properties} whose {@link ConfigKeyInfo#name() names}
+     * matches a given regular expression.
+     * @param config the configuration properties to search; may not be null, but may be empty
+     * @param regex the regular expression to search for; may not be null
+     * @return the configuration properties whose {@link ConfigKeyInfo#name() name}
+     * matches the regular expression. The order of the resulting list will match the iteration order
+     * of the provided {@link Collection}
+     */
+    public static List<ConfigKeyInfo> searchConfigByName(Collection<ConfigKeyInfo> config, Pattern regex) {
+        return searchConfig(config, regex, CONFIG_NAME);
+    }
+
+    /**
+     * Find the {@link ConfigKeyInfo config properties} whose {@link ConfigKeyInfo#documentation() docstring}
+     * matches a given regular expression.
+     * @param config the configuration properties to search; may not be null, but may be empty
+     * @param regex the regular expression to search for; may not be null
+     * @return the configuration properties whose {@link ConfigKeyInfo#documentation() docstring}
+     * matches the regular expression. The order of the resulting list will match the iteration order
+     * of the provided {@link Collection}
+     */
+    public static List<ConfigKeyInfo> searchConfigByDescription(Collection<ConfigKeyInfo> config, Pattern regex) {
+        return searchConfig(config, regex, CONFIG_DESCRIPTION);
+    }
+
+    @SafeVarargs
+    private static List<ConfigKeyInfo> searchConfig(Collection<ConfigKeyInfo> config, Pattern regex, SearchTerm<MutableConfigKeyInfo>... terms) {
+        List<MutableConfigKeyInfo> mutableConfig = config.stream().map(MutableConfigKeyInfo::fromRecord).toList();
+        List<MutableConfigKeyInfo> filteredConfig = search(mutableConfig, regex, terms);
+        return filteredConfig.stream().map(MutableConfigKeyInfo::toRecord).toList();
+    }
+
+    @SafeVarargs
+    private static <E> List<E> search(Collection<E> elements, Pattern regex, SearchTerm<E>... terms) {
+        List<E> result = new ArrayList<>();
+        for (E element : elements) {
+            boolean matched = false;
+            for (SearchTerm<E> term : terms) {
+                // Single-pipe OR operator forces evaluation of both operands, which we want in order
+                // to continue to highlight matched terms even after a match has been established
+                matched = matched | term.matches(element, regex);
+            }
+            if (matched)
+                result.add(element);
+        }
+        return result;
+    }
+
+}

--- a/src/test/java/org/kcctl/util/SearchTest.java
+++ b/src/test/java/org/kcctl/util/SearchTest.java
@@ -41,14 +41,14 @@ public class SearchTest {
         // but not that we can highlight the portions of docstrings that match the regex.
         // We may want to add coverage in the future if this logic is refactored in order to
         // reduce the risk of regression.
-        assertConfigSearchMatch(config, Pattern.compile("p1"), Colors.underline("p1"));
-        assertConfigSearchMatch(config, Pattern.compile("p2"), Colors.underline("p2"));
-        assertConfigSearchMatch(config, Pattern.compile("^p1$"), Colors.underline("p1"));
+        assertConfigSearchMatch(config, Pattern.compile("p1"), Colors.highlight("p1"));
+        assertConfigSearchMatch(config, Pattern.compile("p2"), Colors.highlight("p2"));
+        assertConfigSearchMatch(config, Pattern.compile("^p1$"), Colors.highlight("p1"));
         assertConfigSearchMatch(config, Pattern.compile("^p"),
-                Colors.underline("p") + "1", Colors.underline("p") + "2");
+                Colors.highlight("p") + "1", Colors.highlight("p") + "2");
         assertConfigSearchMatch(config, Pattern.compile("docstring"), "p1", "p2");
         assertConfigSearchMatch(config, Pattern.compile(".*"),
-                Colors.underline("p1"), Colors.underline("p2"));
+                Colors.highlight("p1"), Colors.highlight("p2"));
         assertConfigSearchMatch(config, Pattern.compile("^p$"));
         assertConfigSearchMatch(config, Pattern.compile("^docstring$"));
     }

--- a/src/test/java/org/kcctl/util/SearchTest.java
+++ b/src/test/java/org/kcctl/util/SearchTest.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright 2021 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.kcctl.util;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.kcctl.service.ConfigInfos.ConfigKeyInfo;
+
+public class SearchTest {
+
+    @Test
+    public void testConfigSearch() {
+        List<ConfigKeyInfo> config = Stream.of(
+                new Prop("p1", "p1 docstring"),
+                new Prop("p2", "p2 docstring"))
+                .map(Prop::configKeyInfo)
+                .toList();
+
+        // We assert that we can match by name and by docstring,
+        // and that we can highlight the portions of names that match the regex,
+        // but not that we can highlight the portions of docstrings that match the regex.
+        // We may want to add coverage in the future if this logic is refactored in order to
+        // reduce the risk of regression.
+        assertConfigSearchMatch(config, Pattern.compile("p1"), Colors.underline("p1"));
+        assertConfigSearchMatch(config, Pattern.compile("p2"), Colors.underline("p2"));
+        assertConfigSearchMatch(config, Pattern.compile("^p1$"), Colors.underline("p1"));
+        assertConfigSearchMatch(config, Pattern.compile("^p"),
+                Colors.underline("p") + "1", Colors.underline("p") + "2");
+        assertConfigSearchMatch(config, Pattern.compile("docstring"), "p1", "p2");
+        assertConfigSearchMatch(config, Pattern.compile(".*"),
+                Colors.underline("p1"), Colors.underline("p2"));
+        assertConfigSearchMatch(config, Pattern.compile("^p$"));
+        assertConfigSearchMatch(config, Pattern.compile("^docstring$"));
+    }
+
+    private record Prop(String name, String documentation) {
+        public ConfigKeyInfo configKeyInfo() {
+            return new ConfigKeyInfo(
+                    name,
+                    null,
+                    false,
+                    null,
+                    null,
+                    documentation,
+                    null,
+                    0,
+                    null,
+                    null,
+                    null
+            );
+        }
+    }
+
+    private void assertConfigSearchMatch(List<ConfigKeyInfo> config, Pattern regex, String... expectedNames) {
+        List<String> actualNames = Search.searchConfig(config, regex).stream()
+                .map(ConfigKeyInfo::name)
+                .collect(Collectors.toList());
+        assertEquals(Arrays.asList(expectedNames), actualNames);
+    }
+
+}


### PR DESCRIPTION
Addresses https://github.com/kcctl/kcctl/issues/261

Adds support for the mutually-exclusive flags `--search`, `--search-name`, and `--search-description` to the `kcctl describe plugin` command, including automatic underlining of matches.

I opted to underline instead of bold, highlight, change color, etc. since with my limited prototyping it seemed the most readable option and least likely to interact poorly with terminals whose color schemes differ from mine (I use white font on a black background). Would be interested if anyone has any alternatives to propose.