### PR TITLE
#250 Allow multiple file names with 'apply -f'

### DIFF
--- a/src/main/java/org/kcctl/command/ApplyCommand.java
+++ b/src/main/java/org/kcctl/command/ApplyCommand.java
@@ -60,7 +60,7 @@ public class ApplyCommand implements Callable<Integer> {
     // Support "-f file1.json file2.json" in addition to "-f file1.json -f file2.json" in order to work smoothly with shell
     // globbing (e.g., "-f file*.json")
     @Option(names = { "-f",
-            "--file" }, description = "Names of the file to apply or '-' to read from stdin. You can specify multiple filenames, if the connector names are in the files", required = true, converter = ApplyConnectorConverter.class, arity = "1..*")
+            "--file" }, description = "One or more name(s) of file(s) to apply, or '-' to read from stdin. You can specify multiple file names only if the connector names are in the files", required = true, converter = ApplyConnectorConverter.class, arity = "1..*")
     List applyConnectors;
 
     @Option(names = { "-n", "--name" }, description = "Name of the connector when not given within the file itself")

--- a/src/main/java/org/kcctl/command/ApplyCommand.java
+++ b/src/main/java/org/kcctl/command/ApplyCommand.java
@@ -57,8 +57,10 @@ public class ApplyCommand implements Callable<Integer> {
 
     // Hack : workaround. Should be `List<ApplyConnector>` instead of List.
     // But Graalvm seems to have difficulty building a native binary with ApplyConnector type record in class fields
+    // Support "-f file1.json file2.json" in addition to "-f file1.json -f file2.json" in order to work smoothly with shell
+    // globbing (e.g., "-f file*.json")
     @Option(names = { "-f",
-            "--file" }, description = "Name of the file to apply or '-' to read from stdin. You can specify -f multiple times, if the connector names are in the files", required = true, converter = ApplyConnectorConverter.class)
+            "--file" }, description = "Names of the file to apply or '-' to read from stdin. You can specify multiple filenames, if the connector names are in the files", required = true, converter = ApplyConnectorConverter.class, arity = "1..*")
     List applyConnectors;
 
     @Option(names = { "-n", "--name" }, description = "Name of the connector when not given within the file itself")
@@ -148,7 +150,7 @@ public class ApplyCommand implements Callable<Integer> {
     private void validate() {
         if (applyConnectors.size() > 1 && name != null)
             throw new CommandLine.ParameterException(spec.commandLine(),
-                    "It is not possible to use -n when -f is given multiple times. Please provide the connector names in the connector configuration files.");
+                    "It is not possible to use -n when multiple files are given. Please provide the connector names in the connector configuration files.");
     }
 
     private int applyOrValidateConnector(KafkaConnectApi kafkaConnectApi, ApplyConnector applyConnector) throws Exception {

--- a/src/test/java/org/kcctl/command/ApplyCommandTest.java
+++ b/src/test/java/org/kcctl/command/ApplyCommandTest.java
@@ -20,6 +20,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -45,10 +48,24 @@ class ApplyCommandTest extends IntegrationTest {
     KcctlCommandContext<ApplyCommand> context;
 
     @Test
-    public void should_create_two_connectors() {
+    public void should_create_two_connectors_single_flag() {
+        test_create_two_connectors(false);
+    }
+
+    @Test
+    public void should_create_two_connectors_multiple_flags() {
+        test_create_two_connectors(true);
+    }
+
+    private void test_create_two_connectors(boolean multipleFlags) {
         var path = Paths.get("src", "test", "resources", "heartbeat-source.json");
         var path2 = Paths.get("src", "test", "resources", "heartbeat-source-2.json");
-        int exitCode = context.commandLine().execute("-f", path.toAbsolutePath().toString(), "-f", path2.toAbsolutePath().toString());
+        List<String> args = new ArrayList<>(Arrays.asList("-f", path.toAbsolutePath().toString()));
+        if (multipleFlags) {
+            args.add("-f");
+        }
+        args.add(path2.toAbsolutePath().toString());
+        int exitCode = context.commandLine().execute(args.toArray(new String[0]));
         assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
         assertThat(context.output().toString()).contains("Created connector heartbeat-source", "Created connector heartbeat-source-2");
 


### PR DESCRIPTION
Addresses #250 

Allows multiple files to be specified following a single `-f` flag, in order to work better with shell globbing.

I looked into the possibility of disallowing multiple `-f` flags from being specified, but based on https://github.com/remkop/picocli/issues/190 (which doesn't touch on that exact feature, but something related) and the picocli Javadocs, it appears that that's not supported.