### PR TITLE
#265 replace 'delete' with 'delete connector'

### DIFF
--- a/src/main/java/org/kcctl/command/DeleteCommand.java
+++ b/src/main/java/org/kcctl/command/DeleteCommand.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright 2021 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.kcctl.command;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import org.kcctl.util.ConfigurationContext;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+import javax.inject.Inject;
+
+@Command(name = "delete", subcommands = { DeleteConnectorCommand.class }, description = "Deletes connectors")
+public class DeleteCommand implements Callable<Integer> {
+
+    @CommandLine.Parameters
+    // Hack: without this, picocli will fail to parse any commands that would otherwise get routed to
+    // this class if arguments are provided, making it impossible to display a useful error message to users
+    // who are used to using "delete" instead of "delete connector" to delete connectors
+    // Luckily, even with this args field, picocli is smart enough to route commands like "delete connector foo"
+    // to the DeleteConnectorCommand subcommand class, and send all other commands beginning with
+    // "delete" to this one, so that we can display our helpful error message
+    private List<String> args;
+
+    @CommandLine.Spec
+    CommandLine.Model.CommandSpec spec;
+
+    @Override
+    public Integer call() throws Exception {
+        throw new CommandLine.ParameterException(
+                spec.commandLine(),
+                "To delete a connector, use 'delete connector' instead of 'delete'");
+    }
+
+    @Inject
+    public DeleteCommand(ConfigurationContext context) {
+    }
+
+    // Hack : Picocli currently require an empty constructor to generate the completion file
+    public DeleteCommand() {
+    }
+
+}

--- a/src/main/java/org/kcctl/command/DeleteConnectorCommand.java
+++ b/src/main/java/org/kcctl/command/DeleteConnectorCommand.java
@@ -32,7 +32,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;
 
-@Command(name = "delete", description = "Deletes specified connectors")
+@Command(name = "connector", description = "Deletes specified connectors")
 public class DeleteConnectorCommand implements Callable<Integer> {
     @CommandLine.Option(names = { "-e", "--reg-exp" }, description = "use CONNECTOR NAME(s) as regexp pattern(s) to apply on all connectors")
     boolean regexpMode = false;

--- a/src/main/java/org/kcctl/command/KcCtlCommand.java
+++ b/src/main/java/org/kcctl/command/KcCtlCommand.java
@@ -38,7 +38,7 @@ import picocli.CommandLine.IVersionProvider;
         RestartCommand.class,
         PauseCommand.class,
         ResumeCommand.class,
-        DeleteConnectorCommand.class,
+        DeleteCommand.class,
         CommandLine.HelpCommand.class,
         ConnectorNamesCompletionCandidateCommand.class,
         TaskNamesCompletionCandidateCommand.class,

--- a/src/test/java/org/kcctl/IntegrationTest.java
+++ b/src/test/java/org/kcctl/IntegrationTest.java
@@ -110,8 +110,10 @@ public abstract class IntegrationTest {
         var commandLine = new CommandLine(command);
         var output = new StringWriter();
         commandLine.setOut(new PrintWriter(output));
+        var error = new StringWriter();
+        commandLine.setErr(new PrintWriter(error));
 
-        return new KcctlCommandContext<>(command, commandLine, output);
+        return new KcctlCommandContext<>(command, commandLine, output, error);
     }
 
     private void ensureCaseyCommand(Class<?> targetCommand) {

--- a/src/test/java/org/kcctl/command/DeleteCommandTest.java
+++ b/src/test/java/org/kcctl/command/DeleteCommandTest.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright 2021 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.kcctl.command;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.kcctl.IntegrationTest;
+import org.kcctl.IntegrationTestProfile;
+import org.kcctl.support.InjectCommandContext;
+import org.kcctl.support.KcctlCommandContext;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import picocli.CommandLine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class DeleteCommandTest extends IntegrationTest {
+
+    @InjectCommandContext
+    KcctlCommandContext<DeleteCommand> context;
+
+    @Test
+    public void should_not_delete_connector() {
+        int exitCode = context.commandLine().execute("test1");
+        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.USAGE);
+        assertThat(context.error().toString()).contains("use 'delete connector' instead of 'delete'");
+    }
+
+}

--- a/src/test/java/org/kcctl/support/KcctlCommandContext.java
+++ b/src/test/java/org/kcctl/support/KcctlCommandContext.java
@@ -19,6 +19,6 @@ import java.io.StringWriter;
 
 import picocli.CommandLine;
 
-public record KcctlCommandContext<T>(T command, CommandLine commandLine, StringWriter output) {
+public record KcctlCommandContext<T>(T command, CommandLine commandLine, StringWriter output, StringWriter error) {
 
 }


### PR DESCRIPTION
Addresses #265

The `delete` command is replaced with `delete connector`. A useful error message is added to let users know about the replacement.