### PR TITLE
#295 (follow-up) Fix configuration context for listing plugins when apply fails

### DIFF
--- a/src/main/java/org/kcctl/command/ApplyCommand.java
+++ b/src/main/java/org/kcctl/command/ApplyCommand.java
@@ -198,7 +198,7 @@ public class ApplyCommand implements Callable<Integer> {
 
                 spec.commandLine().getOut().println("Specified class isn't a valid connector type. The following connector type(s) are available:");
 
-                CommandLine getPlugins = new CommandLine(new GetPluginsCommand())
+                CommandLine getPlugins = new CommandLine(new GetPluginsCommand(context))
                         .setOut(spec.commandLine().getOut())
                         .setErr(spec.commandLine().getErr());
                 String pluginTypes = GetPluginsCommand.PluginType.SOURCE + "," + GetPluginsCommand.PluginType.SINK;

--- a/src/test/java/org/kcctl/command/ApplyCommandTest.java
+++ b/src/test/java/org/kcctl/command/ApplyCommandTest.java
@@ -145,9 +145,21 @@ class ApplyCommandTest extends IntegrationTest {
         var path = Paths.get("src", "test", "resources", "nonexistent.json");
 
         int exitCode = context.commandLine().execute("-f", path.toAbsolutePath().toString());
-
         assertThat(exitCode).isEqualTo(CommandLine.ExitCode.SOFTWARE);
-        assertThat(context.output().toString()).contains("Specified class isn't a valid connector type");
+
+        Iterable<String> expectedOutputSubstrings = Arrays.asList(
+                "Specified class isn't a valid connector type",
+                "The following connector type(s) are available",
+                "TYPE",
+                "CLASS",
+                "VERSION",
+                "source",
+                "io.debezium.connector.mysql.MySqlConnector",
+                "org.apache.kafka.connect.mirror.MirrorSourceConnector"
+        );
+        for (String substring : expectedOutputSubstrings) {
+            assertThat(context.output().toString()).contains(substring);
+        }
     }
 
 }


### PR DESCRIPTION
Follow-up that fixes a small bug in https://github.com/kcctl/kcctl/pull/299 and adds better testing coverage for the list-connectors-when-class-not-found logic in `apply`.