### PR TITLE
Update release configuration

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -20,6 +20,11 @@ on:
   push:
     branches: [ main ]
 
+env:
+  JAVA_VERSION: '17'
+  JAVA_DISTRO: 'zulu'
+  GRAAL_VERSION: '22.3.0'
+
 jobs:
   # Build native executable per runner
   build:
@@ -41,8 +46,8 @@ jobs:
 
       - uses: graalvm/setup-graalvm@v1
         with:
-          version: '22.3.0'
-          java-version: '17'
+          version: ${{ env.GRAAL_VERSION }}
+          java-version: ${{ env.JAVA_VERSION }}
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -89,8 +94,8 @@ jobs:
       - name: 'Set up Java'
         uses: actions/setup-java@v3
         with:
-          java-version: 17
-          distribution: 'zulu'
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRO }}
 
       - name: 'Cache Maven packages'
         uses: actions/cache@v3.2.3

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -55,14 +55,14 @@ jobs:
 
       - name: 'Build Native Image (Linux)'
         if: ${{ runner.os == 'Linux' }}
-        run: ./mvnw -B --file pom.xml -Pnative package
+        run: ./mvnw -ntp -B --file pom.xml -Pnative package
 
       - name: 'Build Native Image (macOS, Windows)'
         if: ${{ runner.os == 'macOS' || runner.os == 'Windows' }}
-        run: ./mvnw -B --file pom.xml -Pnative package "-Dquarkus.test.profile.tags=basic"
+        run: ./mvnw -ntp -B --file pom.xml -Pnative package "-Dquarkus.test.profile.tags=basic"
 
       - name: 'Create distribution'
-        run: ./mvnw -B --file pom.xml -Pdist package -DskipTests
+        run: ./mvnw -ntp -B --file pom.xml -Pdist package -DskipTests
 
       - name: 'Upload build artifact'
         uses: actions/upload-artifact@v3
@@ -102,7 +102,7 @@ jobs:
       - name: 'Release with JReleaser'
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./mvnw -B --file pom.xml -Prelease -DartifactsDir=artifacts jreleaser:full-release
+        run: ./mvnw -ntp -B --file pom.xml -Prelease -DartifactsDir=artifacts jreleaser:full-release
 
       - name: JReleaser output
         if: always()

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,12 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-    
+
+env:
+  JAVA_VERSION: '17'
+  JAVA_DISTRO: 'zulu'
+  GRAAL_VERSION: '22.3.0'
+
 jobs:
   build:
     if: startsWith(github.event.head_commit.message, '🏁 Releasing version') != true && startsWith(github.event.head_commit.message, '⬆️  Next version') != true
@@ -34,8 +39,8 @@ jobs:
       - name: 'Set up Java'
         uses: actions/setup-java@v3
         with:
-          java-version: 17
-          distribution: 'zulu'
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRO }}
 
       - name: 'Cache Maven packages'
         uses: actions/cache@v3.2.3

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -45,4 +45,4 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 
       - name: 'Build'
-        run: ./mvnw -B --file pom.xml verify
+        run: ./mvnw -ntp -B --file pom.xml verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,17 +26,27 @@ on:
         description: "Next version"
         required: false
 
+env:
+  JAVA_VERSION: '17'
+  JAVA_DISTRO: 'zulu'
+  GRAAL_VERSION: '22.3.0'
+
 jobs:
   version:
     runs-on: ubuntu-latest
+    outputs:
+      HEAD: ${{ steps.version.outputs.HEAD }}
+      RELEASE_VERSION: ${{ steps.version.outputs.RELEASE_VERSION }}
+      PLAIN_VERSION: ${{ steps.version.outputs.PLAIN_VERSION }}
+      NEXT_VERSION: ${{ steps.version.outputs.NEXT_VERSION }}
     steps:
       - uses: actions/checkout@v3
 
       - name: 'Set up Java'
         uses: actions/setup-java@v3
         with:
-          java-version: 17
-          distribution: 'zulu'
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRO }}
 
       - name: 'Cache Maven packages'
         uses: actions/cache@v3.2.3
@@ -61,18 +71,11 @@ jobs:
           git config --global user.name "GitHub Action"
           git commit -a -m "🏁 Releasing version $RELEASE_VERSION"
           git push origin HEAD:main
-          git rev-parse HEAD > HEAD
-          echo $RELEASE_VERSION > RELEASE_VERSION
-          echo $PLAIN_VERSION > PLAIN_VERSION
-          echo $NEXT_VERSION > NEXT_VERSION
-
-      - name: 'Upload version files'
-        uses: actions/upload-artifact@v3
-        with:
-          name: artifacts
-          path: |
-            HEAD
-            *_VERSION
+          HEAD=$(git rev-parse HEAD)
+          echo "HEAD=$HEAD" >> $GITHUB_OUTPUT
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+          echo "NEXT_VERSION=$NEXT_VERSION" >> $GITHUB_OUTPUT
+          echo "PLAIN_VERSION=$PLAIN_VERSION" >> $GITHUB_OUTPUT
 
   # Build native executable per runner
   build:
@@ -83,21 +86,11 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
-
     steps:
-      - name: 'Download all build artifacts'
-        uses: actions/download-artifact@v3
-
-      - name: 'Read HEAD ref'
-        id: head
-        uses: juliangruber/read-file-action@v1
-        with:
-          path: artifacts/HEAD
-
       - name: 'Check out repository'
         uses: actions/checkout@v3
         with:
-          ref: ${{ steps.head.outputs.content }}
+          ref: ${{ needs.version.outputs.HEAD }}
         
       - name: 'Add Developer Command Prompt for Microsoft Visual C++ '
         if: ${{ runner.os == 'Windows' }}
@@ -105,8 +98,8 @@ jobs:
 
       - uses: graalvm/setup-graalvm@v1
         with:
-          version: '22.3.0'
-          java-version: '17'
+          version: ${{ env.GRAAL_VERSION }}
+          java-version: ${{ env.JAVA_VERSION }}
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -138,37 +131,13 @@ jobs:
 
   # Collect all executables and release
   release:
-    needs: [ build ]
+    needs: [ version, build ]
     runs-on: ubuntu-latest
-
     steps:
-      # must read HEAD before checkout
-      - name: 'Download all build artifacts'
-        uses: actions/download-artifact@v3
-
-      - name: 'Read HEAD ref'
-        id: head
-        uses: juliangruber/read-file-action@v1
-        with:
-          path: artifacts/HEAD
-
-      - name: 'Read versions'
-        id: version
-        run: |
-          RELEASE_VERSION=`cat artifacts/RELEASE_VERSION`
-          PLAIN_VERSION=`cat artifacts/PLAIN_VERSION`
-          NEXT_VERSION=`cat artifacts/NEXT_VERSION`
-          echo "RELEASE_VERSION = $RELEASE_VERSION"
-          echo "PLAIN_VERSION   = $PLAIN_VERSION"
-          echo "NEXT_VERSION    = $NEXT_VERSION"
-          echo "::set-output name=RELEASE_VERSION::$RELEASE_VERSION"
-          echo "::set-output name=PLAIN_VERSION::$PLAIN_VERSION"
-          echo "::set-output name=NEXT_VERSION::$NEXT_VERSION"
-
       - name: 'Check out repository'
         uses: actions/checkout@v3
         with:
-          ref: ${{ steps.head.outputs.content }}
+          ref: ${{ needs.version.outputs.HEAD }}
           fetch-depth: 0
 
       # checkout will clobber downloaded artifacts
@@ -179,8 +148,8 @@ jobs:
       - name: 'Set up Java'
         uses: actions/setup-java@v3
         with:
-          java-version: 17
-          distribution: 'zulu'
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRO }}
 
       - name: 'Cache Maven packages'
         uses: actions/cache@v3.2.3
@@ -208,7 +177,7 @@ jobs:
           
       - name: 'Set next version'
         env:
-          NEXT_VERSION: ${{ steps.version.outputs.NEXT_VERSION }}
+          NEXT_VERSION: ${{ needs.version.outputs.NEXT_VERSION }}
         run: |
           ./mvnw -ntp -B versions:set versions:commit -DnewVersion=$NEXT_VERSION
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           then
             NEXT_VERSION=$COMPUTED_NEXT_VERSION
           fi
-          ./mvnw -B versions:set versions:commit -DnewVersion=$RELEASE_VERSION
+          ./mvnw -ntp -B versions:set versions:commit -DnewVersion=$RELEASE_VERSION
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "GitHub Action"
           git commit -a -m "🏁 Releasing version $RELEASE_VERSION"
@@ -119,14 +119,14 @@ jobs:
 
       - name: 'Build Native Image (Linux)'
         if: ${{ runner.os == 'Linux' }}
-        run: ./mvnw -B --file pom.xml -Pnative package
+        run: ./mvnw -ntp -B --file pom.xml -Pnative package
 
       - name: 'Build Native Image (macOS, Windows)'
         if: ${{ runner.os == 'macOS' || runner.os == 'Windows' }}
-        run: ./mvnw -B --file pom.xml -Pnative package "-Dquarkus.test.profile.tags=basic"
+        run: ./mvnw -ntp -B --file pom.xml -Pnative package "-Dquarkus.test.profile.tags=basic"
 
       - name: 'Create distribution'
-        run: ./mvnw -B --file pom.xml -Pdist package -DskipTests
+        run: ./mvnw -ntp -B --file pom.xml -Pdist package -DskipTests
 
       - name: 'Upload build artifact'
         uses: actions/upload-artifact@v3
@@ -195,7 +195,7 @@ jobs:
           JRELEASER_SDKMAN_CONSUMER_KEY: ${{ secrets.JRELEASER_SDKMAN_CONSUMER_KEY }}
           JRELEASER_SDKMAN_CONSUMER_TOKEN: ${{ secrets.JRELEASER_SDKMAN_CONSUMER_TOKEN }}
           JRELEASER_HOMEBREW_GITHUB_TOKEN: ${{ secrets.JRELEASER_HOMEBREW_GITHUB_TOKEN }}
-        run: ./mvnw -B --file pom.xml -Prelease -DartifactsDir=artifacts jreleaser:full-release
+        run: ./mvnw -ntp -B --file pom.xml -Prelease -DartifactsDir=artifacts jreleaser:full-release
 
       - name: JReleaser output
         if: always()
@@ -210,7 +210,7 @@ jobs:
         env:
           NEXT_VERSION: ${{ steps.version.outputs.NEXT_VERSION }}
         run: |
-          ./mvnw -B versions:set versions:commit -DnewVersion=$NEXT_VERSION
+          ./mvnw -ntp -B versions:set versions:commit -DnewVersion=$NEXT_VERSION
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "GitHub Action"
           git commit -a -m "⬆️  Next version $NEXT_VERSION"

--- a/pom.xml
+++ b/pom.xml
@@ -481,21 +481,17 @@
                     </changelog>
                   </github>
                 </release>
-                <packagers>
-                  <brew>
-                    <active>RELEASE</active>
-                    <continueOnError>true</continueOnError>
-                    <multiPlatform>true</multiPlatform>
-                  </brew>
-                  <sdkman>
-                    <active>RELEASE</active>
-                    <continueOnError>true</continueOnError>
-                  </sdkman>
-                </packagers>
                 <distributions>
                   <kcctl>
                     <name>kcctl</name>
-                    <type>NATIVE_IMAGE</type>
+                    <type>BINARY</type>
+                    <brew>
+                      <active>RELEASE</active>
+                      <multiPlatform>true</multiPlatform>
+                    </brew>
+                    <sdkman>
+                      <active>RELEASE</active>
+                    </sdkman>
                     <artifacts>
                       <artifact>
                         <path>{{artifactsDir}}/{{distributionName}}-{{projectVersion}}-linux-x86_64.tar.gz</path>


### PR DESCRIPTION
Brings the following changes:

- CI: use `-ntp` Maven flag to avoid long logs
- CI: use job output vars instead of files to share data between jobs
- CI: use env vars as constants for common values
- JReleaser: move packagers inside distributions section

Fixes #311