### PR TITLE
#339 Add 'stop connector' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Commands:
   restart   Restarts some connectors or a task
   pause     Pauses connectors
   resume    Resumes connectors
+  stop      Stops (but does not delete) connectors
   delete    Deletes connectors
   help      Display help information about the specified command.
 ```

--- a/kcctl_completion
+++ b/kcctl_completion
@@ -163,6 +163,7 @@ function _complete_kcctl() {
   if [ "${COMP_LINE}" = "${COMP_WORDS[0]} restart" ];    then _picocli_kcctl; return $?; fi
   if [ "${COMP_LINE}" = "${COMP_WORDS[0]} pause" ];    then _picocli_kcctl; return $?; fi
   if [ "${COMP_LINE}" = "${COMP_WORDS[0]} resume" ];    then _picocli_kcctl; return $?; fi
+  if [ "${COMP_LINE}" = "${COMP_WORDS[0]} stop" ];    then _picocli_kcctl; return $?; fi
   if [ "${COMP_LINE}" = "${COMP_WORDS[0]} delete" ];    then _picocli_kcctl; return $?; fi
   if [ "${COMP_LINE}" = "${COMP_WORDS[0]} help" ];    then _picocli_kcctl; return $?; fi
   if [ "${COMP_LINE}" = "${COMP_WORDS[0]} config set-context" ];    then _picocli_kcctl_config; return $?; fi
@@ -187,6 +188,8 @@ function _complete_kcctl() {
   if [ "${COMP_LINE}" = "${COMP_WORDS[0]} pause connectors" ];    then _picocli_kcctl_pause; return $?; fi
   if [ "${COMP_LINE}" = "${COMP_WORDS[0]} resume connector" ];    then _picocli_kcctl_resume; return $?; fi
   if [ "${COMP_LINE}" = "${COMP_WORDS[0]} resume connectors" ];    then _picocli_kcctl_resume; return $?; fi
+  if [ "${COMP_LINE}" = "${COMP_WORDS[0]} stop connector" ];    then _picocli_kcctl_stop; return $?; fi
+  if [ "${COMP_LINE}" = "${COMP_WORDS[0]} stop connectors" ];    then _picocli_kcctl_stop; return $?; fi
   if [ "${COMP_LINE}" = "${COMP_WORDS[0]} delete connector" ];    then _picocli_kcctl_delete; return $?; fi
 
   # Find the longest sequence of subcommands and call the bash function for that subcommand.
@@ -199,57 +202,63 @@ function _complete_kcctl() {
   local cmds6=(restart)
   local cmds7=(pause)
   local cmds8=(resume)
-  local cmds9=(delete)
-  local cmds10=(help)
-  local cmds11=(config set-context)
-  local cmds12=(config get-contexts)
-  local cmds13=(config current-context)
-  local cmds14=(config use-context)
-  local cmds15=(get plugins)
-  local cmds16=(get connectors)
-  local cmds17=(get offsets)
-  local cmds18=(get loggers)
-  local cmds19=(get logger)
-  local cmds20=(describe connector)
-  local cmds21=(describe connectors)
-  local cmds22=(describe plugin)
-  local cmds23=(patch logger)
-  local cmds24=(patch connector)
-  local cmds25=(patch connectors)
-  local cmds26=(restart connector)
-  local cmds27=(restart connectors)
-  local cmds28=(restart task)
-  local cmds29=(pause connector)
-  local cmds30=(pause connectors)
-  local cmds31=(resume connector)
-  local cmds32=(resume connectors)
-  local cmds33=(delete connector)
+  local cmds9=(stop)
+  local cmds10=(delete)
+  local cmds11=(help)
+  local cmds12=(config set-context)
+  local cmds13=(config get-contexts)
+  local cmds14=(config current-context)
+  local cmds15=(config use-context)
+  local cmds16=(get plugins)
+  local cmds17=(get connectors)
+  local cmds18=(get offsets)
+  local cmds19=(get loggers)
+  local cmds20=(get logger)
+  local cmds21=(describe connector)
+  local cmds22=(describe connectors)
+  local cmds23=(describe plugin)
+  local cmds24=(patch logger)
+  local cmds25=(patch connector)
+  local cmds26=(patch connectors)
+  local cmds27=(restart connector)
+  local cmds28=(restart connectors)
+  local cmds29=(restart task)
+  local cmds30=(pause connector)
+  local cmds31=(pause connectors)
+  local cmds32=(resume connector)
+  local cmds33=(resume connectors)
+  local cmds34=(stop connector)
+  local cmds35=(stop connectors)
+  local cmds36=(delete connector)
 
-  if CompWordsContainsArray "${cmds33[@]}"; then _picocli_kcctl_delete_connector; return $?; fi
-  if CompWordsContainsArray "${cmds32[@]}"; then _picocli_kcctl_resume_connectors; return $?; fi
-  if CompWordsContainsArray "${cmds31[@]}"; then _picocli_kcctl_resume_connector; return $?; fi
-  if CompWordsContainsArray "${cmds30[@]}"; then _picocli_kcctl_pause_connectors; return $?; fi
-  if CompWordsContainsArray "${cmds29[@]}"; then _picocli_kcctl_pause_connector; return $?; fi
-  if CompWordsContainsArray "${cmds28[@]}"; then _picocli_kcctl_restart_task; return $?; fi
-  if CompWordsContainsArray "${cmds27[@]}"; then _picocli_kcctl_restart_connectors; return $?; fi
-  if CompWordsContainsArray "${cmds26[@]}"; then _picocli_kcctl_restart_connector; return $?; fi
-  if CompWordsContainsArray "${cmds25[@]}"; then _picocli_kcctl_patch_connectors; return $?; fi
-  if CompWordsContainsArray "${cmds24[@]}"; then _picocli_kcctl_patch_connector; return $?; fi
-  if CompWordsContainsArray "${cmds23[@]}"; then _picocli_kcctl_patch_logger; return $?; fi
-  if CompWordsContainsArray "${cmds22[@]}"; then _picocli_kcctl_describe_plugin; return $?; fi
-  if CompWordsContainsArray "${cmds21[@]}"; then _picocli_kcctl_describe_connectors; return $?; fi
-  if CompWordsContainsArray "${cmds20[@]}"; then _picocli_kcctl_describe_connector; return $?; fi
-  if CompWordsContainsArray "${cmds19[@]}"; then _picocli_kcctl_get_logger; return $?; fi
-  if CompWordsContainsArray "${cmds18[@]}"; then _picocli_kcctl_get_loggers; return $?; fi
-  if CompWordsContainsArray "${cmds17[@]}"; then _picocli_kcctl_get_offsets; return $?; fi
-  if CompWordsContainsArray "${cmds16[@]}"; then _picocli_kcctl_get_connectors; return $?; fi
-  if CompWordsContainsArray "${cmds15[@]}"; then _picocli_kcctl_get_plugins; return $?; fi
-  if CompWordsContainsArray "${cmds14[@]}"; then _picocli_kcctl_config_usecontext; return $?; fi
-  if CompWordsContainsArray "${cmds13[@]}"; then _picocli_kcctl_config_currentcontext; return $?; fi
-  if CompWordsContainsArray "${cmds12[@]}"; then _picocli_kcctl_config_getcontexts; return $?; fi
-  if CompWordsContainsArray "${cmds11[@]}"; then _picocli_kcctl_config_setcontext; return $?; fi
-  if CompWordsContainsArray "${cmds10[@]}"; then _picocli_kcctl_help; return $?; fi
-  if CompWordsContainsArray "${cmds9[@]}"; then _picocli_kcctl_delete; return $?; fi
+  if CompWordsContainsArray "${cmds36[@]}"; then _picocli_kcctl_delete_connector; return $?; fi
+  if CompWordsContainsArray "${cmds35[@]}"; then _picocli_kcctl_stop_connectors; return $?; fi
+  if CompWordsContainsArray "${cmds34[@]}"; then _picocli_kcctl_stop_connector; return $?; fi
+  if CompWordsContainsArray "${cmds33[@]}"; then _picocli_kcctl_resume_connectors; return $?; fi
+  if CompWordsContainsArray "${cmds32[@]}"; then _picocli_kcctl_resume_connector; return $?; fi
+  if CompWordsContainsArray "${cmds31[@]}"; then _picocli_kcctl_pause_connectors; return $?; fi
+  if CompWordsContainsArray "${cmds30[@]}"; then _picocli_kcctl_pause_connector; return $?; fi
+  if CompWordsContainsArray "${cmds29[@]}"; then _picocli_kcctl_restart_task; return $?; fi
+  if CompWordsContainsArray "${cmds28[@]}"; then _picocli_kcctl_restart_connectors; return $?; fi
+  if CompWordsContainsArray "${cmds27[@]}"; then _picocli_kcctl_restart_connector; return $?; fi
+  if CompWordsContainsArray "${cmds26[@]}"; then _picocli_kcctl_patch_connectors; return $?; fi
+  if CompWordsContainsArray "${cmds25[@]}"; then _picocli_kcctl_patch_connector; return $?; fi
+  if CompWordsContainsArray "${cmds24[@]}"; then _picocli_kcctl_patch_logger; return $?; fi
+  if CompWordsContainsArray "${cmds23[@]}"; then _picocli_kcctl_describe_plugin; return $?; fi
+  if CompWordsContainsArray "${cmds22[@]}"; then _picocli_kcctl_describe_connectors; return $?; fi
+  if CompWordsContainsArray "${cmds21[@]}"; then _picocli_kcctl_describe_connector; return $?; fi
+  if CompWordsContainsArray "${cmds20[@]}"; then _picocli_kcctl_get_logger; return $?; fi
+  if CompWordsContainsArray "${cmds19[@]}"; then _picocli_kcctl_get_loggers; return $?; fi
+  if CompWordsContainsArray "${cmds18[@]}"; then _picocli_kcctl_get_offsets; return $?; fi
+  if CompWordsContainsArray "${cmds17[@]}"; then _picocli_kcctl_get_connectors; return $?; fi
+  if CompWordsContainsArray "${cmds16[@]}"; then _picocli_kcctl_get_plugins; return $?; fi
+  if CompWordsContainsArray "${cmds15[@]}"; then _picocli_kcctl_config_usecontext; return $?; fi
+  if CompWordsContainsArray "${cmds14[@]}"; then _picocli_kcctl_config_currentcontext; return $?; fi
+  if CompWordsContainsArray "${cmds13[@]}"; then _picocli_kcctl_config_getcontexts; return $?; fi
+  if CompWordsContainsArray "${cmds12[@]}"; then _picocli_kcctl_config_setcontext; return $?; fi
+  if CompWordsContainsArray "${cmds11[@]}"; then _picocli_kcctl_help; return $?; fi
+  if CompWordsContainsArray "${cmds10[@]}"; then _picocli_kcctl_delete; return $?; fi
+  if CompWordsContainsArray "${cmds9[@]}"; then _picocli_kcctl_stop; return $?; fi
   if CompWordsContainsArray "${cmds8[@]}"; then _picocli_kcctl_resume; return $?; fi
   if CompWordsContainsArray "${cmds7[@]}"; then _picocli_kcctl_pause; return $?; fi
   if CompWordsContainsArray "${cmds6[@]}"; then _picocli_kcctl_restart; return $?; fi
@@ -269,7 +278,7 @@ function _picocli_kcctl() {
   # Get completion data
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
-  local commands="info config get describe apply patch restart pause resume delete help"
+  local commands="info config get describe apply patch restart pause resume stop delete help"
   local flag_opts="-h --help -V --version"
   local arg_opts=""
 
@@ -456,6 +465,24 @@ function _picocli_kcctl_resume() {
   fi
 }
 
+# Generates completions for the options and subcommands of the `stop` subcommand.
+function _picocli_kcctl_stop() {
+  # Get completion data
+  local curr_word=${COMP_WORDS[COMP_CWORD]}
+
+  local commands="connector connectors"
+  local flag_opts=""
+  local arg_opts=""
+
+  if [[ "${curr_word}" == -* ]]; then
+    COMPREPLY=( $(compgen -W "${flag_opts} ${arg_opts}" -- "${curr_word}") )
+  else
+    local positionals=""
+    local IFS=$'\n'
+    COMPREPLY=( $(compgen -W "${commands// /$'\n'}${IFS}${positionals}" -- "${curr_word}") )
+  fi
+}
+
 # Generates completions for the options and subcommands of the `delete` subcommand.
 function _picocli_kcctl_delete() {
   # Get completion data
@@ -479,7 +506,7 @@ function _picocli_kcctl_help() {
   # Get completion data
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
-  local commands="info config get describe apply patch restart pause resume delete"
+  local commands="info config get describe apply patch restart pause resume stop delete"
   local flag_opts="-h --help"
   local arg_opts=""
 
@@ -1076,6 +1103,54 @@ function _picocli_kcctl_resume_connector() {
 
 # Generates completions for the options and subcommands of the `connectors` subcommand.
 function _picocli_kcctl_resume_connectors() {
+  # Get completion data
+  local curr_word=${COMP_WORDS[COMP_CWORD]}
+
+  local commands=""
+  local flag_opts="-e --reg-exp"
+  local arg_opts=""
+  local NAME_pos_param_args=(`kcctl connector-name-completions`) # 0-2147483647 values
+
+  if [[ "${curr_word}" == -* ]]; then
+    COMPREPLY=( $(compgen -W "${flag_opts} ${arg_opts}" -- "${curr_word}") )
+  else
+    local positionals=""
+    local currIndex
+    currIndex=$(currentPositionalIndex "connectors" "${arg_opts}" "${flag_opts}")
+    if (( currIndex >= 0 && currIndex <= 2147483647 )); then
+      positionals=$( compReplyArray "${NAME_pos_param_args[@]}" )
+    fi
+    local IFS=$'\n'
+    COMPREPLY=( $(compgen -W "${commands// /$'\n'}${IFS}${positionals}" -- "${curr_word}") )
+  fi
+}
+
+# Generates completions for the options and subcommands of the `connector` subcommand.
+function _picocli_kcctl_stop_connector() {
+  # Get completion data
+  local curr_word=${COMP_WORDS[COMP_CWORD]}
+
+  local commands=""
+  local flag_opts="-e --reg-exp"
+  local arg_opts=""
+  local NAME_pos_param_args=(`kcctl connector-name-completions`) # 0-2147483647 values
+
+  if [[ "${curr_word}" == -* ]]; then
+    COMPREPLY=( $(compgen -W "${flag_opts} ${arg_opts}" -- "${curr_word}") )
+  else
+    local positionals=""
+    local currIndex
+    currIndex=$(currentPositionalIndex "connector" "${arg_opts}" "${flag_opts}")
+    if (( currIndex >= 0 && currIndex <= 2147483647 )); then
+      positionals=$( compReplyArray "${NAME_pos_param_args[@]}" )
+    fi
+    local IFS=$'\n'
+    COMPREPLY=( $(compgen -W "${commands// /$'\n'}${IFS}${positionals}" -- "${curr_word}") )
+  fi
+}
+
+# Generates completions for the options and subcommands of the `connectors` subcommand.
+function _picocli_kcctl_stop_connectors() {
   # Get completion data
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 

--- a/src/main/java/org/kcctl/command/KcCtlCommand.java
+++ b/src/main/java/org/kcctl/command/KcCtlCommand.java
@@ -38,6 +38,7 @@ import picocli.CommandLine.IVersionProvider;
         RestartCommand.class,
         PauseCommand.class,
         ResumeCommand.class,
+        StopCommand.class,
         DeleteCommand.class,
         CommandLine.HelpCommand.class,
         ConnectorNamesCompletionCandidateCommand.class,

--- a/src/main/java/org/kcctl/command/StopCommand.java
+++ b/src/main/java/org/kcctl/command/StopCommand.java
@@ -1,0 +1,22 @@
+/*
+ *  Copyright 2021 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.kcctl.command;
+
+import picocli.CommandLine.Command;
+
+@Command(name = "stop", subcommands = { StopConnectorCommand.class }, description = "Stops (but does not delete) connectors")
+public class StopCommand {
+}

--- a/src/main/java/org/kcctl/command/StopConnectorCommand.java
+++ b/src/main/java/org/kcctl/command/StopConnectorCommand.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright 2021 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.kcctl.command;
+
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.kcctl.completion.ConnectorNameCompletions;
+import org.kcctl.service.KafkaConnectApi;
+import org.kcctl.util.ConfigurationContext;
+import org.kcctl.util.Connectors;
+import org.kcctl.util.Version;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+@Command(name = "connector", aliases = "connectors", description = "Stops (but does not delete) the specified connector(s)")
+public class StopConnectorCommand implements Callable<Integer> {
+
+    private final Version requiredVersionForStoppingConnectors = new Version(3, 5);
+
+    @CommandLine.Option(names = { "-e", "--reg-exp" }, description = "use NAME(s) as regexp pattern(s) to use on all connectors")
+    boolean regexpMode = false;
+
+    @Parameters(paramLabel = "NAME", description = "Name(s) of the connector(s) (e.g. 'my-connector').", completionCandidates = ConnectorNameCompletions.class)
+    Set<String> names = Set.of();
+
+    @CommandLine.Spec
+    private CommandLine.Model.CommandSpec spec;
+
+    private final ConfigurationContext context;
+
+    @Inject
+    public StopConnectorCommand(ConfigurationContext context) {
+        this.context = context;
+    }
+
+    // Hack : Picocli currently require an empty constructor to generate the completion file
+    public StopConnectorCommand() {
+        context = new ConfigurationContext();
+    }
+
+    @Override
+    public Integer call() {
+        KafkaConnectApi kafkaConnectApi = RestClientBuilder.newBuilder()
+                .baseUri(context.getCurrentContext().getCluster())
+                .build(KafkaConnectApi.class);
+
+        Version currentVersion = new Version(kafkaConnectApi.getWorkerInfo().version());
+
+        if (!currentVersion.greaterOrEquals(requiredVersionForStoppingConnectors)) {
+            spec.commandLine().getErr().println("Stopping connectors requires at least Kafka Connect 3.5. Current version: " + currentVersion);
+            return 1;
+        }
+
+        Set<String> selectedConnectors = Connectors.getSelectedConnectors(kafkaConnectApi, names, regexpMode);
+
+        for (String connectorToStop : selectedConnectors) {
+            kafkaConnectApi.stopConnector(connectorToStop);
+            spec.commandLine().getOut().println("Stopped connector " + connectorToStop);
+        }
+
+        return 0;
+    }
+}

--- a/src/main/java/org/kcctl/service/KafkaConnectApi.java
+++ b/src/main/java/org/kcctl/service/KafkaConnectApi.java
@@ -77,6 +77,10 @@ public interface KafkaConnectApi {
     @Path("/connectors/{name}/resume")
     void resumeConnector(@PathParam("name") String name);
 
+    @PUT
+    @Path("/connectors/{name}/stop")
+    void stopConnector(@PathParam("name") String name);
+
     @DELETE
     @Path("/connectors/{name}")
     void deleteConnector(@PathParam("name") String name);

--- a/src/main/java/org/kcctl/util/Colors.java
+++ b/src/main/java/org/kcctl/util/Colors.java
@@ -46,6 +46,10 @@ public class Colors {
         return switch (state) {
             case "RUNNING" -> ANSI_GREEN + "RUNNING" + ANSI_RESET;
             case "PAUSED" -> ANSI_YELLOW + "PAUSED" + ANSI_RESET;
+            // For Connector objects, STOPPED is identical to PAUSED
+            // The only difference applies to tasks; with PAUSED, tasks stay up but
+            // in an idling state; with STOPPED, all tasks are shut down
+            case "STOPPED" -> ANSI_YELLOW + "STOPPED" + ANSI_RESET;
             case "FAILED" -> ANSI_RED + "FAILED" + ANSI_RESET;
             case "UNASSIGNED" -> ANSI_YELLOW + "UNASSIGNED" + ANSI_RESET;
             default -> state;
@@ -55,6 +59,7 @@ public class Colors {
     public static String replaceColorState(String rawState) {
         return rawState.replace("RUNNING", colorizeState("RUNNING"))
                 .replace("PAUSED", colorizeState("PAUSED"))
+                .replace("STOPPED", colorizeState("STOPPED"))
                 .replace("FAILED", colorizeState("FAILED"))
                 .replace("UNASSIGNED", colorizeState("UNASSIGNED"));
     }

--- a/src/test/java/org/kcctl/command/StopConnectorCommandTest.java
+++ b/src/test/java/org/kcctl/command/StopConnectorCommandTest.java
@@ -1,0 +1,162 @@
+/*
+ *  Copyright 2021 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.kcctl.command;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.kcctl.IntegrationTest;
+import org.kcctl.IntegrationTestProfile;
+import org.kcctl.support.InjectCommandContext;
+import org.kcctl.support.KcctlCommandContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.debezium.testing.testcontainers.Connector;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class StopConnectorCommandTest extends IntegrationTest {
+
+    private static final long CONNECTOR_STOP_TIMEOUT_SECONDS = 10;
+
+    private final OkHttpClient httpClient = new OkHttpClient();
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @InjectCommandContext
+    KcctlCommandContext<StopConnectorCommand> context;
+
+    @BeforeAll
+    public static void prepare() {
+        // TODO: replace explicit container tag with DebeziumContainer.latestStable() once Debezium releases 2.4, which is based on Kafka 3.5
+        kafkaConnect = kafkaConnect24Alpha;
+        IntegrationTest.prepare();
+    }
+
+    @Test
+    public void should_stop_connector() {
+        registerTestConnectors("test1", "test2", "test3");
+        // Make sure that the connectors actually start before we try to stop them
+        ensureConnectorsRunning("test1", "test2", "test3");
+
+        // Then stop some but not all of the connectors
+        context.runAndCheckExitCode("test1", "test2");
+        assertThat(context.output().toString()).contains("Stopped connector test1", "Stopped connector test2");
+        assertThat(context.output().toString()).doesNotContain("Stopped connector test3");
+
+        // Ensure that those connectors are actually stopped
+        ensureConnectorsStopped("test1", "test2");
+        // And ensure that the third connector is still running
+        ensureConnectorsRunning("test3");
+    }
+
+    @Test
+    public void should_stop_connector_with_regexp() {
+        registerTestConnectors("match-1-test", "match-2-test", "nomatch-3-test");
+        // Make sure that the connectors actually start before we try to stop them
+        ensureConnectorsRunning("match-1-test", "match-2-test", "nomatch-3-test");
+
+        // Then stop some but not all of the connectors
+        context.runAndCheckExitCode("--reg-exp", "match-\\d-test");
+        assertThat(context.output().toString()).contains("Stopped connector match-1-test", "Stopped connector match-2-test");
+        assertThat(context.output().toString()).doesNotContain("Stopped connector nomatch-3-test");
+
+        // Ensure that those connectors are actually stopped
+        ensureConnectorsStopped("match-1-test", "match-2-test");
+        // And ensure that the third connector is still running
+        ensureConnectorsRunning("nomatch-3-test");
+    }
+
+    @Test
+    public void should_stop_only_once() {
+        registerTestConnector("test1");
+        ensureConnectorsRunning("test1");
+
+        context.runAndCheckExitCode("test1", "test1", "test1");
+        assertThat(context.output().toString()).containsOnlyOnce("Stopped connector test1");
+
+        ensureConnectorsStopped("test1");
+    }
+
+    @Test
+    public void should_stop_only_once_with_regexp() {
+        registerTestConnectors("match-1-test", "match-2-test", "nomatch-3-test");
+        // Make sure that the connectors actually start before we try to stop them
+        ensureConnectorsRunning("match-1-test", "match-2-test", "nomatch-3-test");
+
+        // Then stop some but not all of the connectors
+        context.runAndCheckExitCode("--reg-exp", "match-\\d-test", "match-.*", "match-1-test");
+        assertThat(context.output().toString()).containsOnlyOnce("Stopped connector match-1-test");
+        assertThat(context.output().toString()).containsOnlyOnce("Stopped connector match-2-test");
+        assertThat(context.output().toString()).doesNotContain("Stopped connector nomatch-3-test");
+
+        // Ensure that those connectors are actually stopped
+        ensureConnectorsStopped("match-1-test", "match-2-test");
+        // And ensure that the third connector is still running
+        ensureConnectorsRunning("nomatch-3-test");
+    }
+
+    private void ensureConnectorsRunning(String... connectors) {
+        for (String connector : connectors) {
+            // Make sure the connector and one task have actually started
+            kafkaConnect.ensureConnectorState(connector, Connector.State.RUNNING);
+            kafkaConnect.ensureConnectorTaskState(connector, 0, Connector.State.RUNNING);
+        }
+    }
+
+    // TODO: Replace this with kafkaConnect.ensureConnectorState if/when
+    // the Debezium testing library is updated with support for the STOPPED state
+    // (https://github.com/debezium/debezium/pull/4709)
+    private void ensureConnectorsStopped(String... connectors) {
+        assertThat(connectors).isNotEmpty();
+        await()
+                .atMost(Duration.ofSeconds(CONNECTOR_STOP_TIMEOUT_SECONDS))
+                .until(() -> {
+                    for (String connector : connectors) {
+                        Request request = new Request.Builder().url(kafkaConnect.getConnectorStatusUri(connector)).build();
+                        try (Response response = httpClient.newCall(request).execute()) {
+                            assertThat(response.isSuccessful()).isTrue();
+                            try (ResponseBody responseBody = response.body()) {
+                                assertThat(responseBody).isNotNull();
+                                ObjectNode parsedObject = (ObjectNode) mapper.readTree(responseBody.string());
+                                // We don't check for an empty set of tasks, since that's the responsibility of the Kafka Connect
+                                // runtime. All that we check for is acknowledgment by the runtime that our request to stop the
+                                // connector was received; if some tasks haven't been shut down, that's a problem with the runtime,
+                                // not kcctl
+                                return "STOPPED".equals(parsedObject.get("connector").get("state").asText());
+                            }
+                        }
+                    }
+                    // Should never happen; we check for an empty connectors list above
+                    throw new IllegalArgumentException("Connectors list cannot be empty");
+                });
+    }
+
+}

--- a/src/test/java/org/kcctl/support/KcctlCommandContext.java
+++ b/src/test/java/org/kcctl/support/KcctlCommandContext.java
@@ -19,6 +19,8 @@ import java.io.StringWriter;
 
 import picocli.CommandLine;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public record KcctlCommandContext<T>(T command, CommandLine commandLine, StringWriter output, StringWriter error) {
 
     /**
@@ -30,4 +32,19 @@ public record KcctlCommandContext<T>(T command, CommandLine commandLine, StringW
         output.getBuffer().setLength(0);
         error.getBuffer().setLength(0);
     }
+
+    /**
+     * Run a command with the given arguments and verify that it has exited successfully
+     * @param args the arguments with which the command should be invoked
+     */
+    public void runAndCheckExitCode(String... args) {
+        int exitCode = commandLine.execute(args);
+        assertThat(exitCode)
+                .overridingErrorMessage(() -> "Command with args '" + String.join("', '", args) + "' "
+                        + "exited with non-zero status " + exitCode + "."
+                        + "\nStdout:\n" + output
+                        + "\nStderr:\n" + error)
+                .isEqualTo(CommandLine.ExitCode.OK);
+    }
+
 }


### PR DESCRIPTION
Addresses https://github.com/kcctl/kcctl/issues/339

Usage:

```
Usage: kcctl stop connector [-e] [NAME...]
Stops (but does not delete) the specified connector(s)
      [NAME...]   Name(s) of the connector(s) (e.g. 'my-connector').
  -e, --reg-exp   use NAME(s) as regexp pattern(s) to use on all connectors
```

Uses the `PUT /connectors/{name}/stop` endpoint introduced in [KIP-875](https://cwiki.apache.org/confluence/display/KAFKA/KIP-875%3A+First-class+offsets+support+in+Kafka+Connect#KIP875:FirstclassoffsetssupportinKafkaConnect-Endpoints) to stop (but not delete) connectors.

Similar to the 'get offsets' command, this feature requires Kafka Connect 3.5 or later, and the integration test is customized to use a non-stable version of Debezium (2.4.0 alpha). We can and should update the version used in that test once a final release takes place for 2.4.0.