### PR TITLE
MINOR: Sprinkle some syntactic sugar on our integration tests

### DIFF
--- a/src/test/java/org/kcctl/IntegrationTest.java
+++ b/src/test/java/org/kcctl/IntegrationTest.java
@@ -62,6 +62,7 @@ public abstract class IntegrationTest {
 
     // TODO: remove this separate container once Debezium releases 2.4, which is based on Kafka 3.5;
     // we can just go back to kafkaConnectLatestStable for all of our tests then
+    // (https://github.com/kcctl/kcctl/issues/346)
     protected static final DebeziumContainer kafkaConnect24Alpha = new DebeziumContainer("debezium/connect:2.4.0.Alpha1")
             .withNetwork(network)
             .withKafka(kafka)

--- a/src/test/java/org/kcctl/command/ApplyCommandTest.java
+++ b/src/test/java/org/kcctl/command/ApplyCommandTest.java
@@ -68,13 +68,12 @@ class ApplyCommandTest extends IntegrationTest {
             args.add("-f");
         }
         args.add(path2.toAbsolutePath().toString());
-        int exitCode = context.commandLine().execute(args.toArray(new String[0]));
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk(args.toArray(new String[0]));
         assertThat(context.output().toString()).contains("Created connector heartbeat-source", "Created connector heartbeat-source-2");
 
         // fix missing admin.bootstrap.servers property exception
         String parameters = "admin.bootstrap.servers=" + getKafkaBootstrapServers();
-        patchContext.commandLine().execute("--set", parameters, "heartbeat-source", "heartbeat-source-2");
+        patchContext.runAndEnsureExitCodeOk("--set", parameters, "heartbeat-source", "heartbeat-source-2");
         System.setProperty("debezium.test.records.waittime", "4");
 
         kafkaConnect.ensureConnectorRegistered("heartbeat-source");
@@ -91,8 +90,7 @@ class ApplyCommandTest extends IntegrationTest {
         InputStream fakeIn = new ByteArrayInputStream(Files.readAllBytes(path));
         System.setIn(fakeIn);
 
-        int exitCode = context.commandLine().execute("-f", "-");
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk("-f", "-");
         assertThat(context.output().toString().trim()).isEqualTo("Created connector heartbeat-source");
 
         // fix missing admin.bootstrap.servers property exception
@@ -108,13 +106,11 @@ class ApplyCommandTest extends IntegrationTest {
     @Test
     public void should_update_connector() {
         var path = Paths.get("src", "test", "resources", "heartbeat-source.json");
-        int exitCode = context.commandLine().execute("-f", path.toAbsolutePath().toString());
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk("-f", path.toAbsolutePath().toString());
         assertThat(context.output().toString().trim()).isEqualTo("Created connector heartbeat-source");
 
         path = Paths.get("src", "test", "resources", "heartbeat-source-update.json");
-        exitCode = context.commandLine().execute("-f", path.toAbsolutePath().toString());
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk("-f", path.toAbsolutePath().toString());
         assertThat(context.output().toString()).isEqualTo("""
                 Created connector heartbeat-source
                 Updated connector heartbeat-source

--- a/src/test/java/org/kcctl/command/ConnectorNamesCompletionCandidateCommandTest.java
+++ b/src/test/java/org/kcctl/command/ConnectorNamesCompletionCandidateCommandTest.java
@@ -25,7 +25,6 @@ import org.kcctl.support.KcctlCommandContext;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import picocli.CommandLine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,11 +38,9 @@ class ConnectorNamesCompletionCandidateCommandTest extends IntegrationTest {
 
     @Test
     public void should_print_connector_names() {
-        registerTestConnector("test1");
-        registerTestConnector("test2");
+        registerTestConnectors("test1", "test2");
 
-        int exitCode = context.commandLine().execute();
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk();
         assertThat(context.output().toString().trim())
                 .isEqualTo("test1 test2");
     }

--- a/src/test/java/org/kcctl/command/DeleteConnectorCommandTest.java
+++ b/src/test/java/org/kcctl/command/DeleteConnectorCommandTest.java
@@ -25,7 +25,6 @@ import org.kcctl.support.KcctlCommandContext;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import picocli.CommandLine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,25 +38,20 @@ class DeleteConnectorCommandTest extends IntegrationTest {
 
     @Test
     public void should_delete_connector() {
-        registerTestConnector("test1");
-        registerTestConnector("test2");
-        registerTestConnector("test3");
+        registerTestConnectors("test1", "test2", "test3");
 
-        int exitCode = context.commandLine().execute("test1", "test2");
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk("test1", "test2");
+
         assertThat(context.output().toString()).contains("Deleted connector test1", "Deleted connector test2");
         assertThat(context.output().toString()).doesNotContain("Deleted connector test3");
     }
 
     @Test
     public void should_delete_connector_with_regexp() {
-        registerTestConnector("match-1-test");
-        registerTestConnector("match-2-test");
-        registerTestConnector("nomatch-3-test");
+        registerTestConnectors("match-1-test", "match-2-test", "nomatch-3-test");
 
-        int exitCode = context.commandLine().execute("--reg-exp", "match-\\d-test");
+        context.runAndEnsureExitCodeOk("--reg-exp", "match-\\d-test");
 
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
         assertThat(context.output().toString()).contains("Deleted connector match-1-test", "Deleted connector match-2-test");
         assertThat(context.output().toString()).doesNotContain("Deleted connector nomatch-3-test");
     }
@@ -66,21 +60,17 @@ class DeleteConnectorCommandTest extends IntegrationTest {
     public void should_delete_only_once() {
         registerTestConnector("test1");
 
-        int exitCode = context.commandLine().execute("test1", "test1", "test1");
+        context.runAndEnsureExitCodeOk("test1", "test1", "test1");
 
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
         assertThat(context.output().toString()).containsOnlyOnce("Deleted connector test1");
     }
 
     @Test
     public void should_delete_only_once_with_regexp() {
-        registerTestConnector("match-1-test");
-        registerTestConnector("match-2-test");
-        registerTestConnector("nomatch-3-test");
+        registerTestConnectors("match-1-test", "match-2-test", "nomatch-3-test");
 
-        int exitCode = context.commandLine().execute("--reg-exp", "match-\\d-test", "match-.*", "match-1-test");
+        context.runAndEnsureExitCodeOk("--reg-exp", "match-\\d-test", "match-.*", "match-1-test");
 
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
         assertThat(context.output().toString()).containsOnlyOnce("Deleted connector match-1-test");
         assertThat(context.output().toString()).containsOnlyOnce("Deleted connector match-2-test");
         assertThat(context.output().toString()).doesNotContain("Deleted connector nomatch-3-test");

--- a/src/test/java/org/kcctl/command/DescribeConnectorCommandTest.java
+++ b/src/test/java/org/kcctl/command/DescribeConnectorCommandTest.java
@@ -28,7 +28,6 @@ import org.kcctl.support.KcctlCommandContext;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import picocli.CommandLine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,18 +41,16 @@ class DescribeConnectorCommandTest extends IntegrationTest {
 
     @Test
     public void should_describe_connector() {
-        registerTestConnector("test1");
-        registerTestConnector("test2");
+        registerTestConnectors("test1", "test2");
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         PrintStream ps = new PrintStream(baos);
         PrintStream old = System.out;
         System.setOut(ps);
 
-        int exitCode = context.commandLine().execute("test1", "test2");
+        context.runAndEnsureExitCodeOk("test1", "test2");
         System.setOut(old);
 
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
         assertThat(baos.toString()).contains(HEARTBEAT_TOPIC);
     }
 
@@ -66,10 +63,9 @@ class DescribeConnectorCommandTest extends IntegrationTest {
         PrintStream old = System.out;
         System.setOut(ps);
 
-        int exitCode = context.commandLine().execute("test1", "--output-format", "json");
+        context.runAndEnsureExitCodeOk("test1", "--output-format", "json");
         System.setOut(old);
 
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
         assertThat(baos.toString()).contains(HEARTBEAT_TOPIC);
         assertThat(baos.toString()).contains("\"name\" : \"test1\",");
     }

--- a/src/test/java/org/kcctl/command/DescribePluginCommandTest.java
+++ b/src/test/java/org/kcctl/command/DescribePluginCommandTest.java
@@ -28,7 +28,6 @@ import org.kcctl.support.KcctlCommandContext;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import picocli.CommandLine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.kcctl.util.Colors.ANSI_RESET;
@@ -48,10 +47,9 @@ class DescribePluginCommandTest extends IntegrationTest {
         PrintStream ps = new PrintStream(baos);
         PrintStream old = System.out;
         System.setOut(ps);
-        int exitCode = context.commandLine().execute("org.apache.kafka.connect.mirror.MirrorCheckpointConnector");
+        context.runAndEnsureExitCodeOk("org.apache.kafka.connect.mirror.MirrorCheckpointConnector");
         System.setOut(old);
 
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
         assertThat(baos.toString()).contains(
                 ANSI_WHITE_BOLD + "Name" + ANSI_RESET + ":           connector.class\n" +
                         ANSI_WHITE_BOLD + "Type" + ANSI_RESET + ":           STRING\n" +
@@ -66,10 +64,9 @@ class DescribePluginCommandTest extends IntegrationTest {
         PrintStream ps = new PrintStream(baos);
         PrintStream old = System.out;
         System.setOut(ps);
-        int exitCode = context.commandLine().execute("org.apache.kafka.connect.transforms.ExtractField$Key");
+        context.runAndEnsureExitCodeOk("org.apache.kafka.connect.transforms.ExtractField$Key");
         System.setOut(old);
 
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
         assertThat(baos.toString()).contains(
                 ANSI_WHITE_BOLD + "Name" + ANSI_RESET + ":           field\n" +
                         ANSI_WHITE_BOLD + "Type" + ANSI_RESET + ":           STRING\n" +

--- a/src/test/java/org/kcctl/command/GetConnectorsCommandTest.java
+++ b/src/test/java/org/kcctl/command/GetConnectorsCommandTest.java
@@ -28,7 +28,6 @@ import org.kcctl.support.KcctlCommandContext;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import picocli.CommandLine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,21 +41,18 @@ class GetConnectorsCommandTest extends IntegrationTest {
 
     @Test
     public void should_print_empty_connectors_() {
-        int exitCode = context.commandLine().execute();
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk();
         assertThat(context.output().toString().trim()).isEqualTo(
                 "NAME   TYPE   STATE   TASKS");
     }
 
     @Test
     public void should_print_registered_connectors() {
-        registerTestConnector("test1");
-        registerTestConnector("test2");
+        registerTestConnectors("test1", "test2");
 
         Pattern singleTaskPattern = Pattern.compile(".*[0-9]+\\:\\s+(.*\\:[0-9]+\\s+).*");
 
-        int exitCode = context.commandLine().execute();
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk();
         assertThat(context.output().toString().trim().lines().map(m -> {
             String ret = m;
             Matcher matcher = singleTaskPattern.matcher(ret);

--- a/src/test/java/org/kcctl/command/GetLoggerCommandTest.java
+++ b/src/test/java/org/kcctl/command/GetLoggerCommandTest.java
@@ -25,7 +25,6 @@ import org.kcctl.support.KcctlCommandContext;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import picocli.CommandLine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,8 +38,7 @@ class GetLoggerCommandTest extends IntegrationTest {
 
     @Test
     public void should_print_all_loggers() {
-        int exitCode = context.commandLine().execute("ALL");
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk("ALL");
         assertThat(context.output().toString().trim().lines())
                 .map(String::trim)
                 .containsExactly(
@@ -51,8 +49,7 @@ class GetLoggerCommandTest extends IntegrationTest {
 
     @Test
     public void should_print_root_logger() {
-        int exitCode = context.commandLine().execute("root");
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk("root");
         assertThat(context.output().toString().trim().lines())
                 .map(String::trim)
                 .containsExactly(
@@ -62,8 +59,7 @@ class GetLoggerCommandTest extends IntegrationTest {
 
     @Test
     public void should_print_reflections_logger() {
-        int exitCode = context.commandLine().execute("org.reflections");
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk("org.reflections");
         assertThat(context.output().toString().trim().lines())
                 .map(String::trim)
                 .containsExactly(

--- a/src/test/java/org/kcctl/command/GetLoggersCommandTest.java
+++ b/src/test/java/org/kcctl/command/GetLoggersCommandTest.java
@@ -25,7 +25,6 @@ import org.kcctl.support.KcctlCommandContext;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import picocli.CommandLine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,8 +38,7 @@ class GetLoggersCommandTest extends IntegrationTest {
 
     @Test
     public void should_print_loggers() {
-        int exitCode = context.commandLine().execute();
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk();
         assertThat(context.output().toString().trim().lines())
                 .map(String::trim)
                 .containsExactly(

--- a/src/test/java/org/kcctl/command/GetOffsetsCommandTest.java
+++ b/src/test/java/org/kcctl/command/GetOffsetsCommandTest.java
@@ -52,6 +52,7 @@ class GetOffsetsCommandTest extends IntegrationTest {
     @BeforeAll
     public static void prepare() {
         // TODO: replace explicit container tag with DebeziumContainer.latestStable() once Debezium releases 2.4, which is based on Kafka 3.5
+        // (https://github.com/kcctl/kcctl/issues/346)
         kafkaConnect = kafkaConnect24Alpha;
         IntegrationTest.prepare();
     }
@@ -64,7 +65,7 @@ class GetOffsetsCommandTest extends IntegrationTest {
                 .atMost(Duration.ofSeconds(OFFSET_AVAILABILITY_TIMEOUT_SECONDS))
                 .until(() -> {
                     context.reset();
-                    context.runAndCheckExitCode("offsets-test1");
+                    context.runAndEnsureExitCodeOk("offsets-test1");
                     String output = context.output().toString();
                     ConnectorOffsets offsets = mapper.readValue(output, ConnectorOffsets.class);
 
@@ -98,7 +99,7 @@ class GetOffsetsCommandTest extends IntegrationTest {
                 .atMost(Duration.ofSeconds(OFFSET_AVAILABILITY_TIMEOUT_SECONDS))
                 .until(() -> {
                     context.reset();
-                    context.runAndCheckExitCode("offsets-test2", "offsets-test3");
+                    context.runAndEnsureExitCodeOk("offsets-test2", "offsets-test3");
                     String output = context.output().toString();
 
                     // Small hack: want to make sure that there's at least one partition/offset

--- a/src/test/java/org/kcctl/command/GetPluginsCommandTest.java
+++ b/src/test/java/org/kcctl/command/GetPluginsCommandTest.java
@@ -29,7 +29,6 @@ import org.kcctl.support.KcctlCommandContext;
 import io.debezium.util.ContainerImageVersions;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import picocli.CommandLine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,8 +45,7 @@ class GetPluginsCommandTest extends IntegrationTest {
         String debeziumVersion = ContainerImageVersions.getStableVersion("debezium/connect");
         String kafkaVersion = getConnectVersion();
 
-        int exitCode = context.commandLine().execute("--types=source");
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk("--types=source");
         assertThat(context.output().toString().trim().lines())
                 .map(String::trim)
                 .containsExactly(
@@ -67,8 +65,7 @@ class GetPluginsCommandTest extends IntegrationTest {
 
     @Test
     public void should_filter_by_type() {
-        int exitCode = context.commandLine().execute("--types=transformation");
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk("--types=transformation");
         assertThat(context.output().toString().trim().lines())
                 .anyMatch(l -> l.startsWith(" transformation"))
                 .anyMatch(l -> l.startsWith("TYPE"));
@@ -76,8 +73,7 @@ class GetPluginsCommandTest extends IntegrationTest {
 
     @Test
     public void should_filter_by_types() {
-        int exitCode = context.commandLine().execute("--types=transformation,converter");
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk("--types=transformation,converter");
         assertThat(context.output().toString().trim().lines())
                 .anyMatch(l -> l.startsWith(" transformation"))
                 .anyMatch(l -> l.startsWith(" converter"))
@@ -86,8 +82,7 @@ class GetPluginsCommandTest extends IntegrationTest {
 
     @Test
     public void should_list_all_types() {
-        int exitCode = context.commandLine().execute();
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk();
         String output = context.output().toString().trim();
         assertThat(output.lines())
                 .anyMatch(l -> l.startsWith(" source"))
@@ -100,8 +95,7 @@ class GetPluginsCommandTest extends IntegrationTest {
 
         context.output().getBuffer().setLength(0);
         String allTypes = Arrays.asList(GetPluginsCommand.PluginType.values()).stream().map(t -> t.name).collect(Collectors.joining(","));
-        exitCode = context.commandLine().execute("--types=" + allTypes);
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk("--types=" + allTypes);
         assertThat(context.output().toString().trim()).isEqualTo(output);
     }
 }

--- a/src/test/java/org/kcctl/command/InfoCommandTest.java
+++ b/src/test/java/org/kcctl/command/InfoCommandTest.java
@@ -25,7 +25,6 @@ import org.kcctl.support.KcctlCommandContext;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import picocli.CommandLine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,8 +38,7 @@ class InfoCommandTest extends IntegrationTest {
 
     @Test
     public void should_print_info() throws Exception {
-        int exitCode = context.commandLine().execute();
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk();
         assertThat(context.output().toString().trim())
                 .matches("URL:\\s+" + kafkaConnect.getTarget() + "\\n" +
                         "Version:\\s+" + getConnectVersion() + "\\n" +

--- a/src/test/java/org/kcctl/command/LoggerNamesCompletionCandidateCommandTest.java
+++ b/src/test/java/org/kcctl/command/LoggerNamesCompletionCandidateCommandTest.java
@@ -25,7 +25,6 @@ import org.kcctl.support.KcctlCommandContext;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import picocli.CommandLine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,8 +38,7 @@ class LoggerNamesCompletionCandidateCommandTest extends IntegrationTest {
 
     @Test
     public void should_print_logger_names() {
-        int exitCode = context.commandLine().execute();
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk();
         assertThat(context.output().toString().trim())
                 .isEqualTo("org.reflections root");
     }

--- a/src/test/java/org/kcctl/command/PatchCommandTest.java
+++ b/src/test/java/org/kcctl/command/PatchCommandTest.java
@@ -27,7 +27,6 @@ import org.kcctl.support.KcctlCommandContext;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import picocli.CommandLine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,18 +40,16 @@ class PatchCommandTest extends IntegrationTest {
 
     @Test
     public void should_patch_two_connectors() {
-        registerTestConnector("test1");
-        registerTestConnector("test2");
+        registerTestConnectors("test1", "test2");
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         PrintStream ps = new PrintStream(baos);
         PrintStream old = System.out;
         System.setOut(ps);
 
-        int exitCode = context.commandLine().execute("--set", "test=true", "test1", "test2");
+        context.runAndEnsureExitCodeOk("--set", "test=true", "test1", "test2");
         System.setOut(old);
 
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
         assertThat(baos.toString()).contains("test:                     true");
     }
 }

--- a/src/test/java/org/kcctl/command/PauseConnectorCommandTest.java
+++ b/src/test/java/org/kcctl/command/PauseConnectorCommandTest.java
@@ -26,7 +26,6 @@ import org.kcctl.support.KcctlCommandContext;
 import io.debezium.testing.testcontainers.Connector;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import picocli.CommandLine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,12 +39,9 @@ class PauseConnectorCommandTest extends IntegrationTest {
 
     @Test
     public void should_pause_connector() {
-        registerTestConnector("test1");
-        registerTestConnector("test2");
-        registerTestConnector("test3");
+        registerTestConnectors("test1", "test2", "test3");
 
-        int exitCode = context.commandLine().execute("test1", "test2");
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk("test1", "test2");
         assertThat(context.output().toString()).contains("Paused connector test1", "Paused connector test2");
         assertThat(context.output().toString()).doesNotContain("Paused connector test3");
 
@@ -56,13 +52,9 @@ class PauseConnectorCommandTest extends IntegrationTest {
 
     @Test
     public void should_pause_connector_with_regexp() {
-        registerTestConnector("match-1-test");
-        registerTestConnector("match-2-test");
-        registerTestConnector("nomatch-3-test");
+        registerTestConnectors("match-1-test", "match-2-test", "nomatch-3-test");
 
-        int exitCode = context.commandLine().execute("--reg-exp", "match-\\d-test");
-
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk("--reg-exp", "match-\\d-test");
         assertThat(context.output().toString()).contains("Paused connector match-1-test", "Paused connector match-2-test");
         assertThat(context.output().toString()).doesNotContain("Paused connector nomatch-3-test");
 
@@ -75,9 +67,7 @@ class PauseConnectorCommandTest extends IntegrationTest {
     public void should_pause_only_once() {
         registerTestConnector("test1");
 
-        int exitCode = context.commandLine().execute("test1", "test1", "test1");
-
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk("test1", "test1", "test1");
         assertThat(context.output().toString()).containsOnlyOnce("Paused connector test1");
 
         kafkaConnect.ensureConnectorState("test1", Connector.State.PAUSED);
@@ -85,13 +75,9 @@ class PauseConnectorCommandTest extends IntegrationTest {
 
     @Test
     public void should_pause_only_once_with_regexp() {
-        registerTestConnector("match-1-test");
-        registerTestConnector("match-2-test");
-        registerTestConnector("nomatch-3-test");
+        registerTestConnectors("match-1-test", "match-2-test", "nomatch-3-test");
 
-        int exitCode = context.commandLine().execute("--reg-exp", "match-\\d-test", "match-.*", "match-1-test");
-
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk("--reg-exp", "match-\\d-test", "match-.*", "match-1-test");
         assertThat(context.output().toString()).containsOnlyOnce("Paused connector match-1-test");
         assertThat(context.output().toString()).containsOnlyOnce("Paused connector match-2-test");
         assertThat(context.output().toString()).doesNotContain("Paused connector nomatch-3-test");

--- a/src/test/java/org/kcctl/command/RestartConnectorCommandTest.java
+++ b/src/test/java/org/kcctl/command/RestartConnectorCommandTest.java
@@ -26,7 +26,6 @@ import org.kcctl.support.KcctlCommandContext;
 import io.debezium.testing.testcontainers.Connector;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import picocli.CommandLine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,12 +39,9 @@ class RestartConnectorCommandTest extends IntegrationTest {
 
     @Test
     public void should_restart_connector() {
-        registerTestConnector("test1");
-        registerTestConnector("test2");
-        registerTestConnector("test3");
+        registerTestConnectors("test1", "test2", "test3");
 
-        int exitCode = context.commandLine().execute("test1", "test2");
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk("test1", "test2");
         assertThat(context.output().toString()).contains("Restarted connector test1", "Restarted connector test2");
         assertThat(context.output().toString()).doesNotContain("Restarted connector test3");
 
@@ -56,13 +52,9 @@ class RestartConnectorCommandTest extends IntegrationTest {
 
     @Test
     public void should_restart_connector_with_regexp() {
-        registerTestConnector("match-1-test");
-        registerTestConnector("match-2-test");
-        registerTestConnector("nomatch-3-test");
+        registerTestConnectors("match-1-test", "match-2-test", "nomatch-3-test");
 
-        int exitCode = context.commandLine().execute("--reg-exp", "match-\\d-test");
-
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk("--reg-exp", "match-\\d-test");
         assertThat(context.output().toString()).contains("Restarted connector match-1-test", "Restarted connector match-2-test");
         assertThat(context.output().toString()).doesNotContain("Restarted connector nomatch-3-test");
 
@@ -75,9 +67,7 @@ class RestartConnectorCommandTest extends IntegrationTest {
     public void should_restart_only_once() {
         registerTestConnector("test1");
 
-        int exitCode = context.commandLine().execute("test1", "test1", "test1");
-
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk("test1", "test1", "test1");
         assertThat(context.output().toString()).containsOnlyOnce("Restarted connector test1");
 
         kafkaConnect.ensureConnectorState("test1", Connector.State.RUNNING);
@@ -85,13 +75,9 @@ class RestartConnectorCommandTest extends IntegrationTest {
 
     @Test
     public void should_restart_only_once_with_regexp() {
-        registerTestConnector("match-1-test");
-        registerTestConnector("match-2-test");
-        registerTestConnector("nomatch-3-test");
+        registerTestConnectors("match-1-test", "match-2-test", "nomatch-3-test");
 
-        int exitCode = context.commandLine().execute("--reg-exp", "match-\\d-test", "match-.*", "match-1-test");
-
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk("--reg-exp", "match-\\d-test", "match-.*", "match-1-test");
         assertThat(context.output().toString()).containsOnlyOnce("Restarted connector match-1-test");
         assertThat(context.output().toString()).containsOnlyOnce("Restarted connector match-2-test");
         assertThat(context.output().toString()).doesNotContain("Restarted connector nomatch-3-test");

--- a/src/test/java/org/kcctl/command/ResumeConnectorCommandTest.java
+++ b/src/test/java/org/kcctl/command/ResumeConnectorCommandTest.java
@@ -26,7 +26,6 @@ import org.kcctl.support.KcctlCommandContext;
 import io.debezium.testing.testcontainers.Connector;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import picocli.CommandLine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,12 +39,9 @@ class ResumeConnectorCommandTest extends IntegrationTest {
 
     @Test
     public void should_resume_connector() {
-        registerTestConnector("test1");
-        registerTestConnector("test2");
-        registerTestConnector("test3");
+        registerTestConnectors("test1", "test2", "test3");
 
-        int exitCode = context.commandLine().execute("test1", "test2");
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk("test1", "test2");
         assertThat(context.output().toString()).contains("Resumed connector test1", "Resumed connector test2");
         assertThat(context.output().toString()).doesNotContain("Resumed connector test3");
 
@@ -56,13 +52,9 @@ class ResumeConnectorCommandTest extends IntegrationTest {
 
     @Test
     public void should_resume_connector_with_regexp() {
-        registerTestConnector("match-1-test");
-        registerTestConnector("match-2-test");
-        registerTestConnector("nomatch-3-test");
+        registerTestConnectors("match-1-test", "match-2-test", "nomatch-3-test");
 
-        int exitCode = context.commandLine().execute("--reg-exp", "match-\\d-test");
-
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk("--reg-exp", "match-\\d-test");
         assertThat(context.output().toString()).contains("Resumed connector match-1-test", "Resumed connector match-2-test");
         assertThat(context.output().toString()).doesNotContain("Resumed connector nomatch-3-test");
 
@@ -75,9 +67,7 @@ class ResumeConnectorCommandTest extends IntegrationTest {
     public void should_resume_only_once() {
         registerTestConnector("test1");
 
-        int exitCode = context.commandLine().execute("test1", "test1", "test1");
-
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk("test1", "test1", "test1");
         assertThat(context.output().toString()).containsOnlyOnce("Resumed connector test1");
 
         kafkaConnect.ensureConnectorState("test1", Connector.State.RUNNING);
@@ -85,13 +75,9 @@ class ResumeConnectorCommandTest extends IntegrationTest {
 
     @Test
     public void should_resume_only_once_with_regexp() {
-        registerTestConnector("match-1-test");
-        registerTestConnector("match-2-test");
-        registerTestConnector("nomatch-3-test");
+        registerTestConnectors("match-1-test", "match-2-test", "nomatch-3-test");
 
-        int exitCode = context.commandLine().execute("--reg-exp", "match-\\d-test", "match-.*", "match-1-test");
-
-        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        context.runAndEnsureExitCodeOk("--reg-exp", "match-\\d-test", "match-.*", "match-1-test");
         assertThat(context.output().toString()).containsOnlyOnce("Resumed connector match-1-test");
         assertThat(context.output().toString()).containsOnlyOnce("Resumed connector match-2-test");
         assertThat(context.output().toString()).doesNotContain("Resumed connector nomatch-3-test");

--- a/src/test/java/org/kcctl/command/StopConnectorCommandTest.java
+++ b/src/test/java/org/kcctl/command/StopConnectorCommandTest.java
@@ -56,6 +56,7 @@ class StopConnectorCommandTest extends IntegrationTest {
     @BeforeAll
     public static void prepare() {
         // TODO: replace explicit container tag with DebeziumContainer.latestStable() once Debezium releases 2.4, which is based on Kafka 3.5
+        // (https://github.com/kcctl/kcctl/issues/346)
         kafkaConnect = kafkaConnect24Alpha;
         IntegrationTest.prepare();
     }
@@ -67,7 +68,7 @@ class StopConnectorCommandTest extends IntegrationTest {
         ensureConnectorsRunning("test1", "test2", "test3");
 
         // Then stop some but not all of the connectors
-        context.runAndCheckExitCode("test1", "test2");
+        context.runAndEnsureExitCodeOk("test1", "test2");
         assertThat(context.output().toString()).contains("Stopped connector test1", "Stopped connector test2");
         assertThat(context.output().toString()).doesNotContain("Stopped connector test3");
 
@@ -84,7 +85,7 @@ class StopConnectorCommandTest extends IntegrationTest {
         ensureConnectorsRunning("match-1-test", "match-2-test", "nomatch-3-test");
 
         // Then stop some but not all of the connectors
-        context.runAndCheckExitCode("--reg-exp", "match-\\d-test");
+        context.runAndEnsureExitCodeOk("--reg-exp", "match-\\d-test");
         assertThat(context.output().toString()).contains("Stopped connector match-1-test", "Stopped connector match-2-test");
         assertThat(context.output().toString()).doesNotContain("Stopped connector nomatch-3-test");
 
@@ -99,7 +100,7 @@ class StopConnectorCommandTest extends IntegrationTest {
         registerTestConnector("test1");
         ensureConnectorsRunning("test1");
 
-        context.runAndCheckExitCode("test1", "test1", "test1");
+        context.runAndEnsureExitCodeOk("test1", "test1", "test1");
         assertThat(context.output().toString()).containsOnlyOnce("Stopped connector test1");
 
         ensureConnectorsStopped("test1");
@@ -112,7 +113,7 @@ class StopConnectorCommandTest extends IntegrationTest {
         ensureConnectorsRunning("match-1-test", "match-2-test", "nomatch-3-test");
 
         // Then stop some but not all of the connectors
-        context.runAndCheckExitCode("--reg-exp", "match-\\d-test", "match-.*", "match-1-test");
+        context.runAndEnsureExitCodeOk("--reg-exp", "match-\\d-test", "match-.*", "match-1-test");
         assertThat(context.output().toString()).containsOnlyOnce("Stopped connector match-1-test");
         assertThat(context.output().toString()).containsOnlyOnce("Stopped connector match-2-test");
         assertThat(context.output().toString()).doesNotContain("Stopped connector nomatch-3-test");

--- a/src/test/java/org/kcctl/support/KcctlCommandContext.java
+++ b/src/test/java/org/kcctl/support/KcctlCommandContext.java
@@ -37,7 +37,7 @@ public record KcctlCommandContext<T>(T command, CommandLine commandLine, StringW
      * Run a command with the given arguments and verify that it has exited successfully
      * @param args the arguments with which the command should be invoked
      */
-    public void runAndCheckExitCode(String... args) {
+    public void runAndEnsureExitCodeOk(String... args) {
         int exitCode = commandLine.execute(args);
         assertThat(exitCode)
                 .overridingErrorMessage(() -> "Command with args '" + String.join("', '", args) + "' "


### PR DESCRIPTION
- Replaces consecutive calls to `IntegrationTest::registerTestConnector` with single calls to `IntegrationTest::registerTestConnectors`
- Replaces all manual verifications that a command exited with status zero with `KcctlCommandContext::runAndCheckExitCode`, which on top of asserting that the command exited successfully, provides the complete contents of stdout/stderr if that assertion fails

This has unearthed a non-deterministic NPE that's occurring in the `PatchConnectorCommandTest` because the `DescribeConnectorCommand` instance that's created and used by `PatchConnectorCommand` has a null `spec` field. Strangely, this is not occurring consistently on my machine. I've been able to reproduce it as far back as 57afec337aecd3ab7cc2bbb65782b682fa51f3bb, so at the very least it's not caused by this PR, or the recent PRs to implement the `get offsets` and `stop connector` commands. We can probably investigate as a follow-up item, and that may even be easier with the changes here (🤞).