### PR TITLE
#357 Retry all REST requests on 409 errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,10 @@
       <artifactId>quarkus-rest-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.github.freva</groupId>
       <artifactId>ascii-table</artifactId>
       <version>1.8.0</version>

--- a/src/main/java/org/kcctl/command/DescribeConnectorCommand.java
+++ b/src/main/java/org/kcctl/command/DescribeConnectorCommand.java
@@ -26,7 +26,7 @@ import org.kcctl.completion.ConnectorNameCompletions;
 import org.kcctl.service.ConnectorInfo;
 import org.kcctl.service.ConnectorStatusInfo;
 import org.kcctl.service.KafkaConnectApi;
-import org.kcctl.service.KafkaConnectException;
+import org.kcctl.service.KafkaConnectNotFoundException;
 import org.kcctl.service.TaskState;
 import org.kcctl.service.TopicsInfo;
 import org.kcctl.util.Colors;
@@ -197,11 +197,7 @@ public class DescribeConnectorCommand implements Callable<Integer> {
                 Tuple.print(topics);
             }
         }
-        catch (KafkaConnectException e) {
-            if (!e.getMessage().contains("not found")) {
-                throw e;
-            }
-
+        catch (KafkaConnectNotFoundException e) {
             spec.commandLine().getOut().println("Connector " + connectorToDescribe + " not found. The following connector(s) are available:");
 
             GetConnectorsCommand getConnectors = new GetConnectorsCommand(context, spec);

--- a/src/main/java/org/kcctl/command/PatchConnectorCommand.java
+++ b/src/main/java/org/kcctl/command/PatchConnectorCommand.java
@@ -15,8 +15,6 @@
  */
 package org.kcctl.command;
 
-import java.time.Duration;
-import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -24,12 +22,10 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
-import javax.ws.rs.core.Response;
 
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.kcctl.completion.ConnectorNameCompletions;
 import org.kcctl.service.KafkaConnectApi;
-import org.kcctl.service.KafkaConnectException;
 import org.kcctl.util.ConfigurationContext;
 import org.kcctl.util.Connectors;
 
@@ -115,28 +111,7 @@ public class PatchConnectorCommand implements Callable<Integer> {
         describeConnectorCommand.includeTasksConfig = false;
 
         System.out.println("New connector configuration:");
-
-        Instant start = Instant.now();
-
-        while (Duration.between(start, Instant.now()).toSeconds() < 30) {
-            try {
-                return describeConnectorCommand.call();
-            }
-            catch (KafkaConnectException kce) {
-                // Request temporarily rejected due to, e.g., a pending rebalance; we can and should try again
-                if (kce.getErrorCode() == Response.Status.CONFLICT.getStatusCode()) {
-                    try {
-                        Thread.sleep(100);
-                    }
-                    catch (InterruptedException ie) {
-                        throw new RuntimeException(ie);
-                    }
-                }
-                else {
-                    throw kce;
-                }
-            }
-        }
+        describeConnectorCommand.call();
 
         return 0;
 

--- a/src/main/java/org/kcctl/service/KafkaConnectApi.java
+++ b/src/main/java/org/kcctl/service/KafkaConnectApi.java
@@ -26,6 +26,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 
+import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
@@ -36,6 +37,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 @RegisterRestClient
 @RegisterClientHeaders(value = KafkaConnectClientHeadersFactory.class)
 @RegisterProvider(value = KafkaConnectResponseExceptionMapper.class, priority = 50)
+@Retry(delay = 100L, maxDuration = 30_000L, retryOn = KafkaConnectConflictException.class)
 public interface KafkaConnectApi {
 
     @GET

--- a/src/main/java/org/kcctl/service/KafkaConnectConflictException.java
+++ b/src/main/java/org/kcctl/service/KafkaConnectConflictException.java
@@ -17,13 +17,10 @@ package org.kcctl.service;
 
 import javax.ws.rs.core.Response;
 
-import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
+public class KafkaConnectConflictException extends KafkaConnectException {
 
-public class KafkaConnectResponseExceptionMapper implements ResponseExceptionMapper<RuntimeException> {
-
-    @Override
-    public RuntimeException toThrowable(Response response) {
-        return KafkaConnectException.from(response);
+    public KafkaConnectConflictException(String message) {
+        super(message, Response.Status.CONFLICT.getStatusCode());
     }
 
 }

--- a/src/main/java/org/kcctl/service/KafkaConnectException.java
+++ b/src/main/java/org/kcctl/service/KafkaConnectException.java
@@ -15,7 +15,25 @@
  */
 package org.kcctl.service;
 
+import javax.ws.rs.core.Response;
+
 public class KafkaConnectException extends RuntimeException {
+
+    public static KafkaConnectException from(Response response) {
+        if (response.getStatusInfo() == Response.Status.UNAUTHORIZED) {
+            return new KafkaConnectException(
+                    response.readEntity(String.class),
+                    Response.Status.UNAUTHORIZED.getStatusCode());
+        }
+
+        ErrorResponse errorResponse = response.readEntity(ErrorResponse.class);
+
+        return switch (response.getStatusInfo().toEnum()) {
+            case CONFLICT -> new KafkaConnectConflictException(errorResponse.message);
+            case NOT_FOUND -> new KafkaConnectNotFoundException(errorResponse.message);
+            default -> new KafkaConnectException(errorResponse);
+        };
+    }
 
     private final int errorCode;
 

--- a/src/main/java/org/kcctl/service/KafkaConnectNotFoundException.java
+++ b/src/main/java/org/kcctl/service/KafkaConnectNotFoundException.java
@@ -17,13 +17,10 @@ package org.kcctl.service;
 
 import javax.ws.rs.core.Response;
 
-import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
+public class KafkaConnectNotFoundException extends KafkaConnectException {
 
-public class KafkaConnectResponseExceptionMapper implements ResponseExceptionMapper<RuntimeException> {
-
-    @Override
-    public RuntimeException toThrowable(Response response) {
-        return KafkaConnectException.from(response);
+    public KafkaConnectNotFoundException(String message) {
+        super(message, Response.Status.NOT_FOUND.getStatusCode());
     }
 
 }


### PR DESCRIPTION
Fixes #357

This uses a different approach than what was proposed in the issue, but the effect should be mostly the same. I drafted up the `retrying(() -> kafkaConnectApi.getConnectorConfig(conectorToPatch))` patch but realized that this would still have to be manually applied to all REST calls that could result in a 409 response, which seemed fairly brittle.

I did some research and it looks like we can get retry logic with our auto-generated REST client for free by bringing in a small extra dependency: https://quarkus.io/guides/smallrye-fault-tolerance

Since the API for describing retriable requests with this library is based on exception class, I added custom subclasses to the `KafkaConnectException` to help us distinguish between retriable and non-retriable operations. We could theoretically create a `RetriableKafkaConnectException` umbrella class for those, but that feels a little premature, especially since some exceptions may be retriable for only a subset of requests that throw them.

I was able to get 10 consecutive green integration test runs locally with this patch.