### PR TITLE
#363 Add nested subcommand support for help

### DIFF
--- a/kcctl_completion
+++ b/kcctl_completion
@@ -297,7 +297,7 @@ function _picocli_kcctl_info() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands=""
-  local flag_opts=""
+  local flag_opts="-h --help"
   local arg_opts=""
 
   if [[ "${curr_word}" == -* ]]; then
@@ -315,7 +315,7 @@ function _picocli_kcctl_config() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands="set-context get-contexts current-context use-context"
-  local flag_opts=""
+  local flag_opts="-h --help"
   local arg_opts=""
 
   if [[ "${curr_word}" == -* ]]; then
@@ -333,7 +333,7 @@ function _picocli_kcctl_get() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands="plugins connectors offsets loggers logger"
-  local flag_opts=""
+  local flag_opts="-h --help"
   local arg_opts=""
 
   if [[ "${curr_word}" == -* ]]; then
@@ -351,7 +351,7 @@ function _picocli_kcctl_describe() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands="connector connectors plugin"
-  local flag_opts=""
+  local flag_opts="-h --help"
   local arg_opts=""
 
   if [[ "${curr_word}" == -* ]]; then
@@ -370,7 +370,7 @@ function _picocli_kcctl_apply() {
   local prev_word=${COMP_WORDS[COMP_CWORD-1]}
 
   local commands=""
-  local flag_opts="--dry-run"
+  local flag_opts="-h --help --dry-run"
   local arg_opts="-f --file -n --name"
 
   type compopt &>/dev/null && compopt +o default
@@ -399,7 +399,7 @@ function _picocli_kcctl_patch() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands="logger connector connectors"
-  local flag_opts=""
+  local flag_opts="-h --help"
   local arg_opts=""
 
   if [[ "${curr_word}" == -* ]]; then
@@ -417,7 +417,7 @@ function _picocli_kcctl_restart() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands="connector connectors task"
-  local flag_opts=""
+  local flag_opts="-h --help"
   local arg_opts=""
 
   if [[ "${curr_word}" == -* ]]; then
@@ -435,7 +435,7 @@ function _picocli_kcctl_pause() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands="connector connectors"
-  local flag_opts=""
+  local flag_opts="-h --help"
   local arg_opts=""
 
   if [[ "${curr_word}" == -* ]]; then
@@ -453,7 +453,7 @@ function _picocli_kcctl_resume() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands="connector connectors"
-  local flag_opts=""
+  local flag_opts="-h --help"
   local arg_opts=""
 
   if [[ "${curr_word}" == -* ]]; then
@@ -471,7 +471,7 @@ function _picocli_kcctl_stop() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands="connector connectors"
-  local flag_opts=""
+  local flag_opts="-h --help"
   local arg_opts=""
 
   if [[ "${curr_word}" == -* ]]; then
@@ -489,7 +489,7 @@ function _picocli_kcctl_delete() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands="connector"
-  local flag_opts=""
+  local flag_opts="-h --help"
   local arg_opts=""
 
   if [[ "${curr_word}" == -* ]]; then
@@ -506,14 +506,20 @@ function _picocli_kcctl_help() {
   # Get completion data
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
-  local commands="info config get describe apply patch restart pause resume stop delete"
+  local commands=""
   local flag_opts="-h --help"
   local arg_opts=""
+  local COMMAND_pos_param_args=("info" "config" "get" "describe" "apply" "patch" "restart" "pause" "resume" "stop" "delete" "help") # 0-2147483647 values
 
   if [[ "${curr_word}" == -* ]]; then
     COMPREPLY=( $(compgen -W "${flag_opts} ${arg_opts}" -- "${curr_word}") )
   else
     local positionals=""
+    local currIndex
+    currIndex=$(currentPositionalIndex "help" "${arg_opts}" "${flag_opts}")
+    if (( currIndex >= 0 && currIndex <= 2147483647 )); then
+      positionals=$( compReplyArray "${COMMAND_pos_param_args[@]}" )
+    fi
     local IFS=$'\n'
     COMPREPLY=( $(compgen -W "${commands// /$'\n'}${IFS}${positionals}" -- "${curr_word}") )
   fi
@@ -526,7 +532,7 @@ function _picocli_kcctl_config_setcontext() {
   local prev_word=${COMP_WORDS[COMP_CWORD-1]}
 
   local commands=""
-  local flag_opts=""
+  local flag_opts="-h --help"
   local arg_opts="--cluster --bootstrap-servers --offset-topic --username --password -o --client-config -f --client-config-file"
 
   type compopt &>/dev/null && compopt +o default
@@ -570,7 +576,7 @@ function _picocli_kcctl_config_getcontexts() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands=""
-  local flag_opts=""
+  local flag_opts="-h --help"
   local arg_opts=""
 
   if [[ "${curr_word}" == -* ]]; then
@@ -588,7 +594,7 @@ function _picocli_kcctl_config_currentcontext() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands=""
-  local flag_opts=""
+  local flag_opts="-h --help"
   local arg_opts=""
 
   if [[ "${curr_word}" == -* ]]; then
@@ -606,7 +612,7 @@ function _picocli_kcctl_config_usecontext() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands=""
-  local flag_opts=""
+  local flag_opts="-h --help"
   local arg_opts=""
   local contextName_pos_param_args=(`kcctl context-name-completions`) # 0-0 values
 
@@ -631,7 +637,7 @@ function _picocli_kcctl_get_plugins() {
   local prev_word=${COMP_WORDS[COMP_CWORD-1]}
 
   local commands=""
-  local flag_opts=""
+  local flag_opts="-h --help"
   local arg_opts="-t --types"
   local pluginTypes_option_args=("source" "sink" "transformation" "converter" "header_converter" "predicate") # --types values
 
@@ -660,7 +666,7 @@ function _picocli_kcctl_get_connectors() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands=""
-  local flag_opts=""
+  local flag_opts="-h --help"
   local arg_opts=""
 
   if [[ "${curr_word}" == -* ]]; then
@@ -678,7 +684,7 @@ function _picocli_kcctl_get_offsets() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands=""
-  local flag_opts=""
+  local flag_opts="-h --help"
   local arg_opts=""
   local NAME_pos_param_args=(`kcctl connector-name-completions`) # 0-2147483647 values
 
@@ -702,7 +708,7 @@ function _picocli_kcctl_get_loggers() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands=""
-  local flag_opts=""
+  local flag_opts="-h --help"
   local arg_opts=""
 
   if [[ "${curr_word}" == -* ]]; then
@@ -720,7 +726,7 @@ function _picocli_kcctl_get_logger() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands=""
-  local flag_opts=""
+  local flag_opts="-h --help"
   local arg_opts=""
   local LOGGER_NAME_pos_param_args=(`kcctl logger-name-completions`) # 0-0 values
 
@@ -745,7 +751,7 @@ function _picocli_kcctl_describe_connector() {
   local prev_word=${COMP_WORDS[COMP_CWORD-1]}
 
   local commands=""
-  local flag_opts="-e --reg-exp --tasks-config"
+  local flag_opts="-h --help -e --reg-exp --tasks-config"
   local arg_opts="-o --output-format"
   local outputFormat_option_args=("json" "text") # --output-format values
 
@@ -781,7 +787,7 @@ function _picocli_kcctl_describe_connectors() {
   local prev_word=${COMP_WORDS[COMP_CWORD-1]}
 
   local commands=""
-  local flag_opts="-e --reg-exp --tasks-config"
+  local flag_opts="-h --help -e --reg-exp --tasks-config"
   local arg_opts="-o --output-format"
   local outputFormat_option_args=("json" "text") # --output-format values
 
@@ -817,7 +823,7 @@ function _picocli_kcctl_describe_plugin() {
   local prev_word=${COMP_WORDS[COMP_CWORD-1]}
 
   local commands=""
-  local flag_opts=""
+  local flag_opts="-h --help"
   local arg_opts="--search --search-name --search-description"
 
   type compopt &>/dev/null && compopt +o default
@@ -856,7 +862,7 @@ function _picocli_kcctl_patch_logger() {
   local prev_word=${COMP_WORDS[COMP_CWORD-1]}
 
   local commands=""
-  local flag_opts=""
+  local flag_opts="-h --help"
   local arg_opts="-l --level"
   local level_option_args=("ERROR" "WARN" "FATAL" "DEBUG" "INFO" "TRACE") # --level values
 
@@ -892,7 +898,7 @@ function _picocli_kcctl_patch_connector() {
   local prev_word=${COMP_WORDS[COMP_CWORD-1]}
 
   local commands=""
-  local flag_opts="-e --reg-exp"
+  local flag_opts="-h --help -e --reg-exp"
   local arg_opts="-s --set -r --remove"
 
   type compopt &>/dev/null && compopt +o default
@@ -928,7 +934,7 @@ function _picocli_kcctl_patch_connectors() {
   local prev_word=${COMP_WORDS[COMP_CWORD-1]}
 
   local commands=""
-  local flag_opts="-e --reg-exp"
+  local flag_opts="-h --help -e --reg-exp"
   local arg_opts="-s --set -r --remove"
 
   type compopt &>/dev/null && compopt +o default
@@ -964,7 +970,7 @@ function _picocli_kcctl_restart_connector() {
   local prev_word=${COMP_WORDS[COMP_CWORD-1]}
 
   local commands=""
-  local flag_opts="-e --reg-exp"
+  local flag_opts="-h --help -e --reg-exp"
   local arg_opts="-t --tasks"
   local tasks_option_args=("all" "failed") # --tasks values
 
@@ -1000,7 +1006,7 @@ function _picocli_kcctl_restart_connectors() {
   local prev_word=${COMP_WORDS[COMP_CWORD-1]}
 
   local commands=""
-  local flag_opts="-e --reg-exp"
+  local flag_opts="-h --help -e --reg-exp"
   local arg_opts="-t --tasks"
   local tasks_option_args=("all" "failed") # --tasks values
 
@@ -1035,7 +1041,7 @@ function _picocli_kcctl_restart_task() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands=""
-  local flag_opts=""
+  local flag_opts="-h --help"
   local arg_opts=""
   local NAME_pos_param_args=(`kcctl task-name-completions`) # 0-0 values
 
@@ -1059,7 +1065,7 @@ function _picocli_kcctl_pause_connector() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands=""
-  local flag_opts="-e --reg-exp"
+  local flag_opts="-h --help -e --reg-exp"
   local arg_opts=""
   local NAME_pos_param_args=(`kcctl connector-name-completions`) # 0-2147483647 values
 
@@ -1083,7 +1089,7 @@ function _picocli_kcctl_pause_connectors() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands=""
-  local flag_opts="-e --reg-exp"
+  local flag_opts="-h --help -e --reg-exp"
   local arg_opts=""
   local NAME_pos_param_args=(`kcctl connector-name-completions`) # 0-2147483647 values
 
@@ -1107,7 +1113,7 @@ function _picocli_kcctl_resume_connector() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands=""
-  local flag_opts="-e --reg-exp"
+  local flag_opts="-h --help -e --reg-exp"
   local arg_opts=""
   local NAME_pos_param_args=(`kcctl connector-name-completions`) # 0-2147483647 values
 
@@ -1131,7 +1137,7 @@ function _picocli_kcctl_resume_connectors() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands=""
-  local flag_opts="-e --reg-exp"
+  local flag_opts="-h --help -e --reg-exp"
   local arg_opts=""
   local NAME_pos_param_args=(`kcctl connector-name-completions`) # 0-2147483647 values
 
@@ -1155,7 +1161,7 @@ function _picocli_kcctl_stop_connector() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands=""
-  local flag_opts="-e --reg-exp"
+  local flag_opts="-h --help -e --reg-exp"
   local arg_opts=""
   local NAME_pos_param_args=(`kcctl connector-name-completions`) # 0-2147483647 values
 
@@ -1179,7 +1185,7 @@ function _picocli_kcctl_stop_connectors() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands=""
-  local flag_opts="-e --reg-exp"
+  local flag_opts="-h --help -e --reg-exp"
   local arg_opts=""
   local NAME_pos_param_args=(`kcctl connector-name-completions`) # 0-2147483647 values
 
@@ -1203,7 +1209,7 @@ function _picocli_kcctl_delete_connector() {
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
   local commands=""
-  local flag_opts="-e --reg-exp"
+  local flag_opts="-h --help -e --reg-exp"
   local arg_opts=""
   local CONNECTOR_NAME_pos_param_args=(`kcctl connector-name-completions`) # 0-2147483647 values
 

--- a/src/main/java/org/kcctl/command/ApplyCommand.java
+++ b/src/main/java/org/kcctl/command/ApplyCommand.java
@@ -55,6 +55,9 @@ public class ApplyCommand implements Callable<Integer> {
         }
     }
 
+    @CommandLine.Mixin
+    HelpMixin help;
+
     // Hack : workaround. Should be `List<ApplyConnector>` instead of List.
     // But Graalvm seems to have difficulty building a native binary with ApplyConnector type record in class fields
     // Support "-f file1.json file2.json" in addition to "-f file1.json -f file2.json" in order to work smoothly with shell

--- a/src/main/java/org/kcctl/command/ConfigCommand.java
+++ b/src/main/java/org/kcctl/command/ConfigCommand.java
@@ -15,6 +15,7 @@
  */
 package org.kcctl.command;
 
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "config", subcommands = { SetContextCommand.class, GetContextsCommand.class,
@@ -22,4 +23,8 @@ import picocli.CommandLine.Command;
 
 )
 public class ConfigCommand {
+
+    @CommandLine.Mixin
+    HelpMixin help;
+
 }

--- a/src/main/java/org/kcctl/command/CurrentContextCommand.java
+++ b/src/main/java/org/kcctl/command/CurrentContextCommand.java
@@ -24,10 +24,14 @@ import com.github.freva.asciitable.AsciiTable;
 import com.github.freva.asciitable.Column;
 import com.github.freva.asciitable.HorizontalAlign;
 
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "current-context", description = "Displays the current context")
 public class CurrentContextCommand implements Runnable {
+
+    @CommandLine.Mixin
+    HelpMixin help;
 
     @Inject
     ConfigurationContext context;

--- a/src/main/java/org/kcctl/command/DeleteCommand.java
+++ b/src/main/java/org/kcctl/command/DeleteCommand.java
@@ -28,6 +28,9 @@ import picocli.CommandLine.Command;
 @Command(name = "delete", subcommands = { DeleteConnectorCommand.class }, description = "Deletes connectors")
 public class DeleteCommand implements Callable<Integer> {
 
+    @CommandLine.Mixin
+    HelpMixin help;
+
     @CommandLine.Parameters
     // Hack: without this, picocli will fail to parse any commands that would otherwise get routed to
     // this class if arguments are provided, making it impossible to display a useful error message to users

--- a/src/main/java/org/kcctl/command/DeleteConnectorCommand.java
+++ b/src/main/java/org/kcctl/command/DeleteConnectorCommand.java
@@ -34,6 +34,9 @@ import picocli.CommandLine.Parameters;
 
 @Command(name = "connector", description = "Deletes specified connectors")
 public class DeleteConnectorCommand implements Callable<Integer> {
+
+    @CommandLine.Mixin
+    HelpMixin help;
     @CommandLine.Option(names = { "-e", "--reg-exp" }, description = "use CONNECTOR NAME(s) as regexp pattern(s) to apply on all connectors")
     boolean regexpMode = false;
 

--- a/src/main/java/org/kcctl/command/DescribeCommand.java
+++ b/src/main/java/org/kcctl/command/DescribeCommand.java
@@ -15,6 +15,7 @@
  */
 package org.kcctl.command;
 
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "describe", subcommands = { DescribeConnectorCommand.class,
@@ -22,4 +23,8 @@ import picocli.CommandLine.Command;
 
 )
 public class DescribeCommand {
+
+    @CommandLine.Mixin
+    HelpMixin help;
+
 }

--- a/src/main/java/org/kcctl/command/DescribeConnectorCommand.java
+++ b/src/main/java/org/kcctl/command/DescribeConnectorCommand.java
@@ -49,6 +49,9 @@ import static org.kcctl.util.Colors.ANSI_WHITE_BOLD;
 @Command(name = "connector", aliases = "connectors", description = "Displays information about given connectors")
 public class DescribeConnectorCommand implements Callable<Integer> {
 
+    @CommandLine.Mixin
+    HelpMixin help;
+
     @CommandLine.Spec
     CommandLine.Model.CommandSpec spec;
 

--- a/src/main/java/org/kcctl/command/DescribePluginCommand.java
+++ b/src/main/java/org/kcctl/command/DescribePluginCommand.java
@@ -67,6 +67,9 @@ public class DescribePluginCommand implements Callable<Integer> {
         }
     }
 
+    @CommandLine.Mixin
+    HelpMixin help;
+
     @CommandLine.Spec
     CommandLine.Model.CommandSpec spec;
 

--- a/src/main/java/org/kcctl/command/GetCommand.java
+++ b/src/main/java/org/kcctl/command/GetCommand.java
@@ -15,10 +15,15 @@
  */
 package org.kcctl.command;
 
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "get", subcommands = { GetPluginsCommand.class, GetConnectorsCommand.class, GetOffsetsCommand.class,
         GetLoggersCommand.class,
         GetLoggerCommand.class }, description = "Displays information about connector plug-ins, connector offsets, created connectors, and loggers")
 public class GetCommand {
+
+    @CommandLine.Mixin
+    HelpMixin help;
+
 }

--- a/src/main/java/org/kcctl/command/GetConnectorsCommand.java
+++ b/src/main/java/org/kcctl/command/GetConnectorsCommand.java
@@ -40,6 +40,8 @@ import picocli.CommandLine.Command;
 @Command(name = "connectors", description = "Displays information about deployed connectors")
 public class GetConnectorsCommand implements Runnable {
 
+    @CommandLine.Mixin
+    HelpMixin help;
     private final ConfigurationContext context;
 
     @CommandLine.Spec

--- a/src/main/java/org/kcctl/command/GetContextsCommand.java
+++ b/src/main/java/org/kcctl/command/GetContextsCommand.java
@@ -26,10 +26,14 @@ import com.github.freva.asciitable.AsciiTable;
 import com.github.freva.asciitable.Column;
 import com.github.freva.asciitable.HorizontalAlign;
 
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "get-contexts", description = "Get all contexts")
 public class GetContextsCommand implements Runnable {
+
+    @CommandLine.Mixin
+    HelpMixin help;
 
     @Inject
     ConfigurationContext configContext;

--- a/src/main/java/org/kcctl/command/GetLoggerCommand.java
+++ b/src/main/java/org/kcctl/command/GetLoggerCommand.java
@@ -41,6 +41,9 @@ import static org.kcctl.util.Colors.ANSI_YELLOW;
 @CommandLine.Command(name = "logger", description = "Displays information about a specific logger")
 public class GetLoggerCommand implements Runnable {
 
+    @CommandLine.Mixin
+    HelpMixin help;
+
     @Parameters(paramLabel = "LOGGER NAME", description = "Name of the logger", completionCandidates = LoggerNameCompletions.class)
     String path;
 

--- a/src/main/java/org/kcctl/command/GetLoggersCommand.java
+++ b/src/main/java/org/kcctl/command/GetLoggersCommand.java
@@ -41,6 +41,9 @@ import static org.kcctl.util.Colors.ANSI_YELLOW;
 @CommandLine.Command(name = "loggers", description = "Displays information about all configured loggers")
 public class GetLoggersCommand implements Runnable {
 
+    @CommandLine.Mixin
+    HelpMixin help;
+
     private final ConfigurationContext context;
 
     @CommandLine.Spec

--- a/src/main/java/org/kcctl/command/GetOffsetsCommand.java
+++ b/src/main/java/org/kcctl/command/GetOffsetsCommand.java
@@ -40,6 +40,9 @@ import picocli.CommandLine;
 @CommandLine.Command(name = "offsets", description = "Displays information about committed connector offsets")
 public class GetOffsetsCommand implements Callable<Integer> {
 
+    @CommandLine.Mixin
+    HelpMixin help;
+
     private final Version requiredVersionForReadingOffsets = new Version(3, 5);
     private final ObjectMapper mapper = new ObjectMapper();
     private final ConfigurationContext context;

--- a/src/main/java/org/kcctl/command/GetPluginsCommand.java
+++ b/src/main/java/org/kcctl/command/GetPluginsCommand.java
@@ -40,6 +40,9 @@ import picocli.CommandLine.Command;
 @Command(name = "plugins", description = "Displays information about available connector plug-ins")
 public class GetPluginsCommand implements Callable<Integer> {
 
+    @CommandLine.Mixin
+    HelpMixin help;
+
     private final Version requiredVersionForAllPlugins = new Version(3, 2);
 
     private final ConfigurationContext context;

--- a/src/main/java/org/kcctl/command/HelpCommand.java
+++ b/src/main/java/org/kcctl/command/HelpCommand.java
@@ -1,0 +1,96 @@
+/*
+ *  Copyright 2021 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.kcctl.command;
+
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kcctl.completion.HelpCompletions;
+
+import picocli.CommandLine;
+
+/**
+ * Adapted from the {@link CommandLine.HelpCommand} class. There are two primary differences:
+ * <ul>
+ *     <li>Information on nested subcommands is available (e.g., {@code kcctl help delete connectors})</li>
+ *     <li>{@link  CommandLine#setAbbreviatedSubcommandsAllowed(boolean) Abbreviation of subcommands} is not supported (this feature is not currently used in kcctl)</li>
+ * </ul>
+ */
+@CommandLine.Command(name = "help", header = {
+        "Display help information about the specified command." }, synopsisHeading = "%nUsage: ", helpCommand = true, description = {
+                "%nWhen no COMMAND is given, the usage help for the main command is displayed.", "If a COMMAND is specified, the help for that command is shown.%n" })
+public class HelpCommand implements CommandLine.IHelpCommandInitializable2, Runnable {
+
+    // Help for help!
+    @CommandLine.Mixin
+    HelpMixin help;
+    @CommandLine.Parameters(paramLabel = "COMMAND", arity = "0..*", completionCandidates = HelpCompletions.class, description = {
+            "The COMMAND to display the usage help message for." })
+    private List<String> commands;
+    private CommandLine self;
+    private PrintWriter outWriter;
+    private PrintWriter errWriter;
+    private CommandLine.Help.ColorScheme colorScheme;
+
+    public HelpCommand() {
+    }
+
+    @Override
+    public void run() {
+        CommandLine parent = this.self == null ? null : this.self.getParent();
+        if (parent != null) {
+            if (this.commands != null && !this.commands.isEmpty()) {
+                CommandLine parentCommand = parent;
+                CommandLine subCommand = null;
+                List<String> fullCommandPath = new ArrayList<>();
+                for (String command : commands) {
+                    fullCommandPath.add(command);
+
+                    subCommand = parentCommand
+                            .getCommandSpec()
+                            .subcommands()
+                            .get(command);
+
+                    if (subCommand == null) {
+                        throw new CommandLine.ParameterException(
+                                parent,
+                                "Unknown command: '" + String.join(" ", fullCommandPath) + "'.",
+                                null,
+                                command);
+                    }
+
+                    parentCommand = subCommand;
+                }
+
+                subCommand.usage(this.outWriter, this.colorScheme);
+            }
+            else {
+                parent.usage(this.outWriter, this.colorScheme);
+            }
+
+        }
+    }
+
+    @Override
+    public void init(CommandLine helpCommandLine, CommandLine.Help.ColorScheme colorScheme, PrintWriter out, PrintWriter err) {
+        this.self = helpCommandLine;
+        this.colorScheme = colorScheme;
+        this.outWriter = out;
+        this.errWriter = err;
+    }
+
+}

--- a/src/main/java/org/kcctl/command/HelpMixin.java
+++ b/src/main/java/org/kcctl/command/HelpMixin.java
@@ -16,12 +16,10 @@
 package org.kcctl.command;
 
 import picocli.CommandLine;
-import picocli.CommandLine.Command;
 
-@Command(name = "pause", subcommands = { PauseConnectorCommand.class }, description = "Pauses connectors")
-public class PauseCommand {
+public class HelpMixin {
 
-    @CommandLine.Mixin
-    HelpMixin help;
+    @CommandLine.Option(names = { "-h", "--help" }, usageHelp = true, description = "Show this help message and exit.")
+    private boolean help;
 
 }

--- a/src/main/java/org/kcctl/command/InfoCommand.java
+++ b/src/main/java/org/kcctl/command/InfoCommand.java
@@ -22,12 +22,16 @@ import org.kcctl.service.KafkaConnectApi;
 import org.kcctl.service.KafkaConnectInfo;
 import org.kcctl.util.ConfigurationContext;
 
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Spec;
 
 @Command(name = "info", description = "Displays information about the Kafka Connect cluster")
 public class InfoCommand implements Runnable {
+
+    @CommandLine.Mixin
+    HelpMixin help;
 
     private final ConfigurationContext context;
 

--- a/src/main/java/org/kcctl/command/KcCtlCommand.java
+++ b/src/main/java/org/kcctl/command/KcCtlCommand.java
@@ -40,12 +40,12 @@ import picocli.CommandLine.IVersionProvider;
         ResumeCommand.class,
         StopCommand.class,
         DeleteCommand.class,
-        CommandLine.HelpCommand.class,
+        HelpCommand.class,
         ConnectorNamesCompletionCandidateCommand.class,
         TaskNamesCompletionCandidateCommand.class,
         LoggerNamesCompletionCandidateCommand.class,
         ContextNamesCompletionCandidateCommand.class,
-        PluginNamesCompletionCandidateCommand.class
+        PluginNamesCompletionCandidateCommand.class,
 }, description = "A command-line interface for Kafka Connect"
 
 )

--- a/src/main/java/org/kcctl/command/PatchCommand.java
+++ b/src/main/java/org/kcctl/command/PatchCommand.java
@@ -15,9 +15,14 @@
  */
 package org.kcctl.command;
 
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "patch", subcommands = { PatchLogLevelCommand.class,
         PatchConnectorCommand.class }, description = "Modifies the configuration of some connectors or a logger")
 public class PatchCommand {
+
+    @CommandLine.Mixin
+    HelpMixin help;
+
 }

--- a/src/main/java/org/kcctl/command/PatchConnectorCommand.java
+++ b/src/main/java/org/kcctl/command/PatchConnectorCommand.java
@@ -32,6 +32,7 @@ import org.kcctl.util.Connectors;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
@@ -41,6 +42,9 @@ import picocli.CommandLine.Spec;
 
 @Command(name = "connector", aliases = "connectors", description = "Patches the specified connector(s) with the given configuration parameters")
 public class PatchConnectorCommand implements Callable<Integer> {
+
+    @CommandLine.Mixin
+    HelpMixin help;
 
     @Spec
     CommandSpec commandSpec;

--- a/src/main/java/org/kcctl/command/PatchLogLevelCommand.java
+++ b/src/main/java/org/kcctl/command/PatchLogLevelCommand.java
@@ -31,7 +31,10 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "logger", description = "Changes the log level of given class/Connector path")
-public class PatchLogLevelCommand implements Callable {
+public class PatchLogLevelCommand implements Callable<Object> {
+
+    @CommandLine.Mixin
+    HelpMixin help;
 
     @Inject
     ConfigurationContext context;

--- a/src/main/java/org/kcctl/command/PauseConnectorCommand.java
+++ b/src/main/java/org/kcctl/command/PauseConnectorCommand.java
@@ -31,6 +31,10 @@ import picocli.CommandLine.Parameters;
 
 @Command(name = "connector", aliases = "connectors", description = "Pauses the specified connector(s)")
 public class PauseConnectorCommand implements Runnable {
+
+    @CommandLine.Mixin
+    HelpMixin help;
+
     @CommandLine.Option(names = { "-e", "--reg-exp" }, description = "use NAME(s) as regexp pattern(s) to use on all connectors")
     boolean regexpMode = false;
 

--- a/src/main/java/org/kcctl/command/RestartCommand.java
+++ b/src/main/java/org/kcctl/command/RestartCommand.java
@@ -15,8 +15,13 @@
  */
 package org.kcctl.command;
 
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "restart", subcommands = { RestartConnectorCommand.class, RestartTaskCommand.class }, description = "Restarts some connectors or a task")
 public class RestartCommand {
+
+    @CommandLine.Mixin
+    HelpMixin help;
+
 }

--- a/src/main/java/org/kcctl/command/RestartConnectorCommand.java
+++ b/src/main/java/org/kcctl/command/RestartConnectorCommand.java
@@ -35,6 +35,9 @@ import picocli.CommandLine.Parameters;
 @Command(name = "connector", aliases = "connectors", description = "Restarts the specified connector(s)")
 public class RestartConnectorCommand implements Callable<Integer> {
 
+    @CommandLine.Mixin
+    HelpMixin help;
+
     private final Version requiredVersionForIncludingTasks = new Version(3, 0);
     @CommandLine.Option(names = { "-e", "--reg-exp" }, description = "use NAME(s) as regexp pattern(s) to use on all connectors")
     boolean regexpMode = false;

--- a/src/main/java/org/kcctl/command/RestartTaskCommand.java
+++ b/src/main/java/org/kcctl/command/RestartTaskCommand.java
@@ -22,11 +22,15 @@ import org.kcctl.completion.TaskNameCompletions;
 import org.kcctl.service.KafkaConnectApi;
 import org.kcctl.util.ConfigurationContext;
 
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;
 
-@Command(name = "task", description = "Restarts the specified connector or task")
+@Command(name = "task", description = "Restarts the specified task")
 public class RestartTaskCommand implements Runnable {
+
+    @CommandLine.Mixin
+    HelpMixin help;
 
     @Inject
     ConfigurationContext context;

--- a/src/main/java/org/kcctl/command/ResumeCommand.java
+++ b/src/main/java/org/kcctl/command/ResumeCommand.java
@@ -15,8 +15,13 @@
  */
 package org.kcctl.command;
 
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "resume", subcommands = { ResumeConnectorCommand.class }, description = "Resumes connectors")
 public class ResumeCommand {
+
+    @CommandLine.Mixin
+    HelpMixin help;
+
 }

--- a/src/main/java/org/kcctl/command/ResumeConnectorCommand.java
+++ b/src/main/java/org/kcctl/command/ResumeConnectorCommand.java
@@ -31,6 +31,10 @@ import picocli.CommandLine.Parameters;
 
 @Command(name = "connector", aliases = "connectors", description = "Resumes the specified connector(s)")
 public class ResumeConnectorCommand implements Runnable {
+
+    @CommandLine.Mixin
+    HelpMixin help;
+
     @CommandLine.Option(names = { "-e", "--reg-exp" }, description = "use NAME(s) as regexp pattern(s) to use on all connectors")
     boolean regexpMode = false;
 

--- a/src/main/java/org/kcctl/command/SetContextCommand.java
+++ b/src/main/java/org/kcctl/command/SetContextCommand.java
@@ -28,12 +28,16 @@ import org.kcctl.service.Context;
 import org.kcctl.util.ConfigurationContext;
 import org.kcctl.util.Strings;
 
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 @Command(name = "set-context", description = "Configures the specified context with the provided arguments")
 public class SetContextCommand implements Callable<Integer> {
+
+    @CommandLine.Mixin
+    HelpMixin help;
 
     @Parameters(index = "0", description = "Context name")
     String contextName;

--- a/src/main/java/org/kcctl/command/StopCommand.java
+++ b/src/main/java/org/kcctl/command/StopCommand.java
@@ -15,8 +15,13 @@
  */
 package org.kcctl.command;
 
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "stop", subcommands = { StopConnectorCommand.class }, description = "Stops (but does not delete) connectors")
 public class StopCommand {
+
+    @CommandLine.Mixin
+    HelpMixin help;
+
 }

--- a/src/main/java/org/kcctl/command/StopConnectorCommand.java
+++ b/src/main/java/org/kcctl/command/StopConnectorCommand.java
@@ -34,6 +34,9 @@ import picocli.CommandLine.Parameters;
 @Command(name = "connector", aliases = "connectors", description = "Stops (but does not delete) the specified connector(s)")
 public class StopConnectorCommand implements Callable<Integer> {
 
+    @CommandLine.Mixin
+    HelpMixin help;
+
     private final Version requiredVersionForStoppingConnectors = new Version(3, 5);
 
     @CommandLine.Option(names = { "-e", "--reg-exp" }, description = "use NAME(s) as regexp pattern(s) to use on all connectors")

--- a/src/main/java/org/kcctl/command/UseContextCommand.java
+++ b/src/main/java/org/kcctl/command/UseContextCommand.java
@@ -18,11 +18,15 @@ package org.kcctl.command;
 import org.kcctl.completion.ContextNameCompletions;
 import org.kcctl.util.ConfigurationContext;
 
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;
 
 @Command(name = "use-context", description = "Configures kcctl to use the specified context")
 public class UseContextCommand implements Runnable {
+
+    @CommandLine.Mixin
+    HelpMixin help;
 
     @Parameters(index = "0", description = "Context name", completionCandidates = ContextNameCompletions.class)
     String contextName;

--- a/src/main/java/org/kcctl/completion/HelpCompletions.java
+++ b/src/main/java/org/kcctl/completion/HelpCompletions.java
@@ -13,15 +13,24 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.kcctl.command;
+package org.kcctl.completion;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import org.kcctl.command.KcCtlCommand;
 
 import picocli.CommandLine;
-import picocli.CommandLine.Command;
 
-@Command(name = "pause", subcommands = { PauseConnectorCommand.class }, description = "Pauses connectors")
-public class PauseCommand {
+public class HelpCompletions implements Iterable<String> {
 
-    @CommandLine.Mixin
-    HelpMixin help;
+    @Override
+    public Iterator<String> iterator() {
+        CommandLine commandLine = new CommandLine(new KcCtlCommand());
+        return commandLine.getSubcommands().entrySet().stream()
+                .filter(e -> !e.getValue().getCommandSpec().usageMessage().hidden())
+                .map(Map.Entry::getKey)
+                .iterator();
+    }
 
 }

--- a/src/test/java/org/kcctl/command/RestartConnectorCommandTest.java
+++ b/src/test/java/org/kcctl/command/RestartConnectorCommandTest.java
@@ -24,11 +24,11 @@ import org.kcctl.IntegrationTest;
 import org.kcctl.IntegrationTestProfile;
 import org.kcctl.support.InjectCommandContext;
 import org.kcctl.support.KcctlCommandContext;
+import org.kcctl.support.SkipIfConnectVersionIsOlderThan;
 
 import io.debezium.testing.testcontainers.Connector;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
-import org.kcctl.support.SkipIfConnectVersionIsOlderThan;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
Fixes #363 

Augments the `help` command to process nested subcommands, and adds support for the `-h`/`--help` flag to every subcommand.

Before:
```
> kcctl help restart connectors
Usage: kcctl restart [COMMAND]
Restarts some connectors or a task
Commands:
  connector, connectors  Restarts the specified connector(s)
  task                   Restarts the specified connector or task
```

(This shows the usage info for `restart`, even though we requested it for `restart connectors`)

After:
```
> kcctl help restart connectors
Usage: kcctl restart connector [-eh] [-t=<tasks>] [NAME...]
Restarts the specified connector(s)
      [NAME...]         Name of the connector (e.g. 'my-connector')
  -e, --reg-exp         use NAME(s) as regexp pattern(s) to use on all
                          connectors
  -h, --help            Show this help message and exit.
  -t, --tasks=<tasks>   also restart tasks for the connector(s); valid values:
                          all, failed
```


Before:
```
> kcctl restart connectors -h
Unknown option: '-h'
Usage: kcctl restart connector [-e] [NAME...]
Restarts the specified connector(s)
      [NAME...]   Name of the connector (e.g. 'my-connector')
  -e, --reg-exp   use NAME(s) as regexp pattern(s) to use on all connectors
```
(Prints an error message about `-h` being an unknown option)

After:
```
> kcctl restart connectors -h
Usage: kcctl restart connector [-eh] [-t=<tasks>] [NAME...]
Restarts the specified connector(s)
      [NAME...]         Name of the connector (e.g. 'my-connector')
  -e, --reg-exp         use NAME(s) as regexp pattern(s) to use on all
                          connectors
  -h, --help            Show this help message and exit.
  -t, --tasks=<tasks>   also restart tasks for the connector(s); valid values:
                          all, failed
```


There is one small drawback to this approach in that it adds a bit of noise to the usage summary for every command. Commands that accepted a single argument or flag now have info on one additional flag (`-h`/`--help`).

Autocomplete is supported, but only for top-level commands. This behavior mirrors current autocomplete support for the `help` command, which repeatedly recommends top-level commands even though only the first one is used. Ideally we could support autocomplete for nested subcommands, but this may be difficult to do with picocli.