### PR TITLE
Add Dockerfile to build a kafka connect image based on kafka trunk

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,26 @@
+FROM debezium/connect:latest
+
+USER root
+
+RUN microdnf -y install git java-11-openjdk-devel
+
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk
+ENV KAFKA_HOME /kafka
+RUN export JAVA_HOME
+
+RUN cd /tmp && \
+    git clone https://github.com/apache/kafka.git -b trunk && \
+    cd kafka && \
+    ./gradlew clean releaseTarGz --rerun-tasks
+
+RUN rm -rf $KAFKA_HOME/libs/* && \
+    tar -xzf /tmp/kafka/core/build/distributions/kafka_*-SNAPSHOT.tgz -C $KAFKA_HOME --strip-components 1 &&\
+    rm -f /tmp/kafka/core/build/distributions/kafka_*-SNAPSHOT.tgz &&\
+    chmod -R g+w,o+w $KAFKA_HOME
+
+#
+# Allow random UID to use Kafka
+#
+RUN chmod -R g+w,o+w $KAFKA_HOME
+
+USER kafka

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,18 @@
+#
+#  Copyright 2021 The original authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
 FROM debezium/connect:latest
 
 USER root
@@ -5,17 +20,18 @@ USER root
 RUN microdnf -y install git java-11-openjdk-devel
 
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk
-ENV KAFKA_HOME /kafka
-RUN export JAVA_HOME
 
 RUN cd /tmp && \
     git clone https://github.com/apache/kafka.git -b trunk && \
     cd kafka && \
+    grep "version=" gradle.properties | sed 's/version=//g' > $KAFKA_HOME/kafka_version && \
     ./gradlew clean releaseTarGz --rerun-tasks
 
-RUN rm -rf $KAFKA_HOME/libs/* && \
+RUN mv $KAFKA_HOME/config/log4j.properties $KAFKA_HOME/config/log4j.properties.back && \
+    rm -rf $KAFKA_HOME/libs/* && \
     tar -xzf /tmp/kafka/core/build/distributions/kafka_*-SNAPSHOT.tgz -C $KAFKA_HOME --strip-components 1 &&\
     rm -f /tmp/kafka/core/build/distributions/kafka_*-SNAPSHOT.tgz &&\
+    mv $KAFKA_HOME/config/log4j.properties.back $KAFKA_HOME/config/log4j.properties && \
     chmod -R g+w,o+w $KAFKA_HOME
 
 #

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>2.16.2.Final</quarkus.platform.version>
-    <debezium.version>2.1.2.Final</debezium.version>
+    <debezium.version>2.3.2.Final</debezium.version>
     <artifactsDir>target</artifactsDir>
   </properties>
 
@@ -121,6 +121,13 @@
       <groupId>io.debezium</groupId>
       <artifactId>debezium-testing-testcontainers</artifactId>
       <version>${debezium.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.debezium</groupId>
+      <artifactId>debezium-core</artifactId>
+      <version>${debezium.version}</version>
+      <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -313,6 +320,7 @@
           <aggregate>true</aggregate>
           <excludes>
             <exclude>LICENSE.txt</exclude>
+            <exclude>**/Dockerfile</exclude>
           </excludes>
         </configuration>
         <executions>

--- a/src/test/java/org/kcctl/ConnectTrunkDebeziumContainer.java
+++ b/src/test/java/org/kcctl/ConnectTrunkDebeziumContainer.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2021 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.kcctl;
+
+import io.debezium.testing.testcontainers.DebeziumContainer;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+
+public class ConnectTrunkDebeziumContainer extends DebeziumContainer {
+
+    public static final String DEBEZIUM_CONNECT_TRUNK_IMAGE_NAME = "debezium-connect:trunk";
+    public static final String DOCKERFILE_PATH = "docker/Dockerfile";
+    public static final String DOCKERFILE_NAME = "Dockerfile";
+
+    public ConnectTrunkDebeziumContainer() {
+
+        super(new ImageFromDockerfile(DEBEZIUM_CONNECT_TRUNK_IMAGE_NAME, false)
+                .withFileFromClasspath(DOCKERFILE_NAME, DOCKERFILE_PATH));
+    }
+}

--- a/src/test/java/org/kcctl/ConnectTrunkDebeziumContainer.java
+++ b/src/test/java/org/kcctl/ConnectTrunkDebeziumContainer.java
@@ -20,7 +20,7 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
 
 public class ConnectTrunkDebeziumContainer extends DebeziumContainer {
 
-    public static final String DEBEZIUM_CONNECT_TRUNK_IMAGE_NAME = "debezium-connect:trunk";
+    public static final String DEBEZIUM_CONNECT_TRUNK_IMAGE_NAME = "debezium/connect:trunk";
     public static final String DOCKERFILE_PATH = "docker/Dockerfile";
     public static final String DOCKERFILE_NAME = "Dockerfile";
 

--- a/src/test/resources/docker/Dockerfile
+++ b/src/test/resources/docker/Dockerfile
@@ -24,6 +24,7 @@ ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk
 RUN cd /tmp && \
     git clone https://github.com/apache/kafka.git -b trunk && \
     cd kafka && \
+    ls && \
     grep "version=" gradle.properties | sed 's/version=//g' > $KAFKA_HOME/kafka_version && \
     ./gradlew clean releaseTarGz --rerun-tasks
 


### PR DESCRIPTION
I have created a Dockerfile based on the debezium-connect image. 
This will simply add all the necessary stuff to build Kafka from the trunk branch. 

Just did some tests and seems that it is working. 

```bash
[mvitale@mvitale connect-config]$ kcctl apply -f postgres-connector-reg.json 
Created connector inventory-connector
[mvitale@mvitale connect-config]$ curl -X GET -H "Accept:application/json" localhost:8083/connectors/inventory-connector/offsets
{"offsets":[{"partition":{"server":"dbserver1"},"offset":{"last_snapshot_record":true,"lsn":34487416,"txId":768,"ts_usec":1691678351957450,"snapshot":true}}]}
[mvitale@mvitale connect-config]$ curl -X DELETE -H "Accept:application/json" localhost:8083/connectors/inventory-connector/offsets
{"error_code":400,"message":"Connectors must be in the STOPPED state before their offsets can be modified. This can be done for the specified connector by issuing a 'PUT' request to the '/connectors/inventory-connector/stop' endpoint"}
[mvitale@mvitale connect-config]$ curl -X PUT -H "Accept:application/json" localhost:8083/connectors/inventory-connector/stop
[mvitale@mvitale connect-config]$ curl -X DELETE -H "Accept:application/json" localhost:8083/connectors/inventory-connector/offsets
{"message":"The Connect framework-managed offsets for this connector have been reset successfully. However, if this connector manages offsets externally, they will need to be manually reset in the system that the connector uses."}
[mvitale@mvitale connect-config]$ curl -X GET -H "Accept:application/json" localhost:8083/connectors/inventory-connector/offsets
{"offsets":[]}
```

