### PR TITLE
#374 Add 'patch offsets' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ Commands:
   describe  Displays detailed information about the specified resources
   apply     Applies the given files or the stdin content for registering or
               updating connectors
-  patch     Modifies the configuration of some connectors or a logger
+  patch     Modifies connector offsets, connector configurations, or logger
+              levels
   restart   Restarts some connectors or a task
   pause     Pauses connectors
   resume    Resumes connectors

--- a/kcctl_completion
+++ b/kcctl_completion
@@ -181,6 +181,7 @@ function _complete_kcctl() {
   if [ "${COMP_LINE}" = "${COMP_WORDS[0]} patch logger" ];    then _picocli_kcctl_patch; return $?; fi
   if [ "${COMP_LINE}" = "${COMP_WORDS[0]} patch connector" ];    then _picocli_kcctl_patch; return $?; fi
   if [ "${COMP_LINE}" = "${COMP_WORDS[0]} patch connectors" ];    then _picocli_kcctl_patch; return $?; fi
+  if [ "${COMP_LINE}" = "${COMP_WORDS[0]} patch offsets" ];    then _picocli_kcctl_patch; return $?; fi
   if [ "${COMP_LINE}" = "${COMP_WORDS[0]} restart connector" ];    then _picocli_kcctl_restart; return $?; fi
   if [ "${COMP_LINE}" = "${COMP_WORDS[0]} restart connectors" ];    then _picocli_kcctl_restart; return $?; fi
   if [ "${COMP_LINE}" = "${COMP_WORDS[0]} restart task" ];    then _picocli_kcctl_restart; return $?; fi
@@ -220,27 +221,29 @@ function _complete_kcctl() {
   local cmds24=(patch logger)
   local cmds25=(patch connector)
   local cmds26=(patch connectors)
-  local cmds27=(restart connector)
-  local cmds28=(restart connectors)
-  local cmds29=(restart task)
-  local cmds30=(pause connector)
-  local cmds31=(pause connectors)
-  local cmds32=(resume connector)
-  local cmds33=(resume connectors)
-  local cmds34=(stop connector)
-  local cmds35=(stop connectors)
-  local cmds36=(delete connector)
+  local cmds27=(patch offsets)
+  local cmds28=(restart connector)
+  local cmds29=(restart connectors)
+  local cmds30=(restart task)
+  local cmds31=(pause connector)
+  local cmds32=(pause connectors)
+  local cmds33=(resume connector)
+  local cmds34=(resume connectors)
+  local cmds35=(stop connector)
+  local cmds36=(stop connectors)
+  local cmds37=(delete connector)
 
-  if CompWordsContainsArray "${cmds36[@]}"; then _picocli_kcctl_delete_connector; return $?; fi
-  if CompWordsContainsArray "${cmds35[@]}"; then _picocli_kcctl_stop_connectors; return $?; fi
-  if CompWordsContainsArray "${cmds34[@]}"; then _picocli_kcctl_stop_connector; return $?; fi
-  if CompWordsContainsArray "${cmds33[@]}"; then _picocli_kcctl_resume_connectors; return $?; fi
-  if CompWordsContainsArray "${cmds32[@]}"; then _picocli_kcctl_resume_connector; return $?; fi
-  if CompWordsContainsArray "${cmds31[@]}"; then _picocli_kcctl_pause_connectors; return $?; fi
-  if CompWordsContainsArray "${cmds30[@]}"; then _picocli_kcctl_pause_connector; return $?; fi
-  if CompWordsContainsArray "${cmds29[@]}"; then _picocli_kcctl_restart_task; return $?; fi
-  if CompWordsContainsArray "${cmds28[@]}"; then _picocli_kcctl_restart_connectors; return $?; fi
-  if CompWordsContainsArray "${cmds27[@]}"; then _picocli_kcctl_restart_connector; return $?; fi
+  if CompWordsContainsArray "${cmds37[@]}"; then _picocli_kcctl_delete_connector; return $?; fi
+  if CompWordsContainsArray "${cmds36[@]}"; then _picocli_kcctl_stop_connectors; return $?; fi
+  if CompWordsContainsArray "${cmds35[@]}"; then _picocli_kcctl_stop_connector; return $?; fi
+  if CompWordsContainsArray "${cmds34[@]}"; then _picocli_kcctl_resume_connectors; return $?; fi
+  if CompWordsContainsArray "${cmds33[@]}"; then _picocli_kcctl_resume_connector; return $?; fi
+  if CompWordsContainsArray "${cmds32[@]}"; then _picocli_kcctl_pause_connectors; return $?; fi
+  if CompWordsContainsArray "${cmds31[@]}"; then _picocli_kcctl_pause_connector; return $?; fi
+  if CompWordsContainsArray "${cmds30[@]}"; then _picocli_kcctl_restart_task; return $?; fi
+  if CompWordsContainsArray "${cmds29[@]}"; then _picocli_kcctl_restart_connectors; return $?; fi
+  if CompWordsContainsArray "${cmds28[@]}"; then _picocli_kcctl_restart_connector; return $?; fi
+  if CompWordsContainsArray "${cmds27[@]}"; then _picocli_kcctl_patch_offsets; return $?; fi
   if CompWordsContainsArray "${cmds26[@]}"; then _picocli_kcctl_patch_connectors; return $?; fi
   if CompWordsContainsArray "${cmds25[@]}"; then _picocli_kcctl_patch_connector; return $?; fi
   if CompWordsContainsArray "${cmds24[@]}"; then _picocli_kcctl_patch_logger; return $?; fi
@@ -398,7 +401,7 @@ function _picocli_kcctl_patch() {
   # Get completion data
   local curr_word=${COMP_WORDS[COMP_CWORD]}
 
-  local commands="logger connector connectors"
+  local commands="logger connector connectors offsets"
   local flag_opts="-h --help"
   local arg_opts=""
 
@@ -957,6 +960,51 @@ function _picocli_kcctl_patch_connectors() {
     currIndex=$(currentPositionalIndex "connectors" "${arg_opts}" "${flag_opts}")
     if (( currIndex >= 0 && currIndex <= 2147483647 )); then
       positionals=$( compReplyArray "${CONNECTOR_NAME_pos_param_args[@]}" )
+    fi
+    local IFS=$'\n'
+    COMPREPLY=( $(compgen -W "${commands// /$'\n'}${IFS}${positionals}" -- "${curr_word}") )
+  fi
+}
+
+# Generates completions for the options and subcommands of the `offsets` subcommand.
+function _picocli_kcctl_patch_offsets() {
+  # Get completion data
+  local curr_word=${COMP_WORDS[COMP_CWORD]}
+  local prev_word=${COMP_WORDS[COMP_CWORD-1]}
+
+  local commands=""
+  local flag_opts="-h --help"
+  local arg_opts="--kafka-topic --kafka-partition --kafka-offset --source-partition --source-offset"
+
+  type compopt &>/dev/null && compopt +o default
+
+  case ${prev_word} in
+    --kafka-topic)
+      return
+      ;;
+    --kafka-partition)
+      return
+      ;;
+    --kafka-offset)
+      return
+      ;;
+    --source-partition)
+      return
+      ;;
+    --source-offset)
+      return
+      ;;
+  esac
+  local NAME_pos_param_args=(`kcctl connector-name-completions`) # 0-0 values
+
+  if [[ "${curr_word}" == -* ]]; then
+    COMPREPLY=( $(compgen -W "${flag_opts} ${arg_opts}" -- "${curr_word}") )
+  else
+    local positionals=""
+    local currIndex
+    currIndex=$(currentPositionalIndex "offsets" "${arg_opts}" "${flag_opts}")
+    if (( currIndex >= 0 && currIndex <= 0 )); then
+      positionals=$( compReplyArray "${NAME_pos_param_args[@]}" )
     fi
     local IFS=$'\n'
     COMPREPLY=( $(compgen -W "${commands// /$'\n'}${IFS}${positionals}" -- "${curr_word}") )

--- a/src/main/java/org/kcctl/command/DeleteOffsetsCommand.java
+++ b/src/main/java/org/kcctl/command/DeleteOffsetsCommand.java
@@ -27,9 +27,6 @@ import org.kcctl.service.KafkaConnectApi;
 import org.kcctl.util.ConfigurationContext;
 import org.kcctl.util.Version;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import picocli.CommandLine;
 
 /**
@@ -44,7 +41,6 @@ public class DeleteOffsetsCommand implements Callable<Integer> {
     HelpMixin help;
 
     private final Version requiredVersionForDeletingOffsets = new Version(3, 6);
-    private final ObjectMapper mapper = new ObjectMapper();
     private final ConfigurationContext context;
 
     @CommandLine.Spec
@@ -64,7 +60,7 @@ public class DeleteOffsetsCommand implements Callable<Integer> {
     }
 
     @Override
-    public Integer call() throws JsonProcessingException {
+    public Integer call() {
         KafkaConnectApi kafkaConnectApi = RestClientBuilder.newBuilder()
                 .baseUri(context.getCurrentContext().getCluster())
                 .build(KafkaConnectApi.class);

--- a/src/main/java/org/kcctl/command/PatchCommand.java
+++ b/src/main/java/org/kcctl/command/PatchCommand.java
@@ -19,7 +19,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "patch", subcommands = { PatchLogLevelCommand.class,
-        PatchConnectorCommand.class }, description = "Modifies the configuration of some connectors or a logger")
+        PatchConnectorCommand.class, PatchOffsetsCommand.class }, description = "Modifies the configuration of some connectors or a logger")
 public class PatchCommand {
 
     @CommandLine.Mixin

--- a/src/main/java/org/kcctl/command/PatchCommand.java
+++ b/src/main/java/org/kcctl/command/PatchCommand.java
@@ -19,7 +19,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "patch", subcommands = { PatchLogLevelCommand.class,
-        PatchConnectorCommand.class, PatchOffsetsCommand.class }, description = "Modifies the configuration of some connectors or a logger")
+        PatchConnectorCommand.class, PatchOffsetsCommand.class }, description = "Modifies connector offsets, connector configurations, or logger levels")
 public class PatchCommand {
 
     @CommandLine.Mixin

--- a/src/main/java/org/kcctl/command/PatchOffsetsCommand.java
+++ b/src/main/java/org/kcctl/command/PatchOffsetsCommand.java
@@ -1,0 +1,169 @@
+/*
+ *  Copyright 2021 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.kcctl.command;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.kcctl.completion.ConnectorNameCompletions;
+import org.kcctl.service.AlterResetOffsetsResponse;
+import org.kcctl.service.ConnectorOffset;
+import org.kcctl.service.ConnectorOffsets;
+import org.kcctl.service.KafkaConnectApi;
+import org.kcctl.util.ConfigurationContext;
+import org.kcctl.util.Version;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import picocli.CommandLine;
+
+/**
+ * Patches the committed offsets for a connector.
+ *
+ * @see <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-875%3A+First-class+offsets+support+in+Kafka+Connect">KIP-875</a>
+ */
+@CommandLine.Command(name = "offsets", description = "Patches committed connector offsets")
+public class PatchOffsetsCommand implements Callable<Integer> {
+
+    @CommandLine.Mixin
+    HelpMixin help;
+
+    private final Version requiredVersionForPatchingOffsets = new Version(3, 6);
+    private final ConfigurationContext context;
+
+    @CommandLine.Spec
+    CommandLine.Model.CommandSpec spec;
+
+    @CommandLine.Parameters(paramLabel = "NAME", description = "Name of the connector (e.g. 'my-connector')", completionCandidates = ConnectorNameCompletions.class)
+    String name;
+
+    static class SinkConnectorOffset {
+        @CommandLine.Option(names = "--kafka-topic", required = true, description = "Name of the Kafka topic (for sink connectors)")
+        String topic;
+
+        @CommandLine.Option(names = "--kafka-partition", required = true, description = "Partition of the Kafka topic (for sink connectors)")
+        int partition;
+
+        @CommandLine.Option(names = "--kafka-offset", required = true, description = "Desired offset of the Kafka topic (for sink connectors)")
+        long offset;
+    }
+
+    static class SourceConnectorOffset {
+        @CommandLine.Option(names = "--source-partition", required = true, type = Map.class, converter = JsonObjectConverter.class, description = "Partition (for source connectors), as a JSON object")
+        Object partition;
+
+        @CommandLine.Option(names = "--source-offset", required = true, type = Map.class, converter = JsonObjectConverter.class, description = "Desired offset (for source connectors), as a JSON object")
+        Object offset;
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> partition() {
+            // Dirty hack to evade PicoCLI's automatic parsing for Map fields,
+            // which it expects to come in key=value format
+            // We declare the field with a type of Object, but a converter that
+            // automatically parses it as a JSON object into a Map<String, Object>
+            return (Map<String, Object>) partition;
+        }
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> offset() {
+            // Dirty hack to evade PicoCLI's automatic parsing for Map fields,
+            // which it expects to come in key=value format
+            // We declare the field with a type of Object, but a converter that
+            // automatically parses it as a JSON object into a Map<String, Object>
+            return (Map<String, Object>) offset;
+        }
+    }
+
+    static class JsonObjectConverter implements CommandLine.ITypeConverter<Map<String, Object>> {
+
+        private static final ObjectMapper mapper = new ObjectMapper();
+
+        @Override
+        public Map<String, Object> convert(String s) throws Exception {
+            return mapper.readValue(s, new TypeReference<>() {
+            });
+        }
+
+    }
+
+    static class PatchedConnectorOffset {
+        @CommandLine.ArgGroup(exclusive = false)
+        SinkConnectorOffset sinkConnectorOffset;
+
+        @CommandLine.ArgGroup(exclusive = false)
+        SourceConnectorOffset sourceConnectorOffset;
+
+        ConnectorOffset offset() {
+            Map<String, Object> partition;
+            Map<String, Object> offset;
+            if (sinkConnectorOffset != null) {
+                partition = new HashMap<>();
+                partition.put("kafka_topic", sinkConnectorOffset.topic);
+                partition.put("kafka_partition", sinkConnectorOffset.partition);
+                offset = Collections.singletonMap("kafka_offset", sinkConnectorOffset.offset);
+            }
+            else if (sourceConnectorOffset != null) {
+                partition = sourceConnectorOffset.partition();
+                offset = sourceConnectorOffset.offset();
+            }
+            else {
+                throw new IllegalStateException("At least one of sink and source offsets should be non-null");
+            }
+            return new ConnectorOffset(partition, offset);
+        }
+    }
+
+    @CommandLine.ArgGroup(exclusive = true)
+    PatchedConnectorOffset patchedOffset;
+
+    @Inject
+    public PatchOffsetsCommand(ConfigurationContext context) {
+        this.context = context;
+    }
+
+    // Hack : Picocli currently require an empty constructor to generate the completion file
+    public PatchOffsetsCommand() {
+        context = new ConfigurationContext();
+    }
+
+    @Override
+    public Integer call() throws JsonProcessingException {
+        KafkaConnectApi kafkaConnectApi = RestClientBuilder.newBuilder()
+                .baseUri(context.getCurrentContext().getCluster())
+                .build(KafkaConnectApi.class);
+
+        Version currentVersion = new Version(kafkaConnectApi.getWorkerInfo().version());
+
+        if (!currentVersion.greaterOrEquals(requiredVersionForPatchingOffsets)) {
+            spec.commandLine().getErr().println(String.format("Patching connector offsets requires at least Kafka Connect %s. Current version: %s",
+                    requiredVersionForPatchingOffsets, currentVersion));
+            return 1;
+        }
+
+        ConnectorOffsets connectorOffsets = new ConnectorOffsets(Collections.singletonList(patchedOffset.offset()));
+        AlterResetOffsetsResponse offsets = kafkaConnectApi.patchConnectorOffsets(name, connectorOffsets);
+        spec.commandLine().getOut().println(offsets.message());
+
+        return 0;
+    }
+
+}

--- a/src/main/java/org/kcctl/service/KafkaConnectApi.java
+++ b/src/main/java/org/kcctl/service/KafkaConnectApi.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
@@ -121,6 +122,10 @@ public interface KafkaConnectApi {
     @DELETE
     @Path("/connectors/{name}/offsets")
     AlterResetOffsetsResponse deleteConnectorOffsets(@PathParam("name") String name);
+
+    @PATCH
+    @Path("/connectors/{name}/offsets")
+    AlterResetOffsetsResponse patchConnectorOffsets(@PathParam("name") String name, ConnectorOffsets offsets);
 
     @POST
     @Path("/connectors/{name}/tasks/{id}/restart")

--- a/src/test/java/org/kcctl/command/PatchOffsetsCommandTest.java
+++ b/src/test/java/org/kcctl/command/PatchOffsetsCommandTest.java
@@ -1,0 +1,130 @@
+/*
+ *  Copyright 2021 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.kcctl.command;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.kcctl.IntegrationTest;
+import org.kcctl.IntegrationTestProfile;
+import org.kcctl.service.ConnectorOffsets;
+import org.kcctl.support.InjectCommandContext;
+import org.kcctl.support.KcctlCommandContext;
+import org.kcctl.support.SkipIfConnectVersionIsOlderThan;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.debezium.testing.testcontainers.Connector;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import picocli.CommandLine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SkipIfConnectVersionIsOlderThan("3.6")
+class PatchOffsetsCommandTest extends IntegrationTest {
+
+    private static final long OFFSET_AVAILABILITY_TIMEOUT_SECONDS = 30;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @InjectCommandContext
+    KcctlCommandContext<PatchOffsetsCommand> patchContext;
+
+    @InjectCommandContext
+    KcctlCommandContext<GetOffsetsCommand> getContext;
+
+    @InjectCommandContext
+    KcctlCommandContext<StopConnectorCommand> stopContext;
+
+    @Test
+    public void patch_offsets_of_running_connector_should_return_error() {
+
+        registerTestConnector("patch-offsets-test1");
+
+        await()
+                .atMost(Duration.ofSeconds(OFFSET_AVAILABILITY_TIMEOUT_SECONDS))
+                .until(() -> {
+                    patchContext.reset();
+
+                    // No offsets have been committed yet; wait a little longer for an offset commit to complete
+                    return isOffsetAvailable("patch-offsets-test1");
+                });
+
+        int exitCode = patchContext.commandLine().execute("--source-partition", "{}", "--source-offset", "{}", "patch-offsets-test1");
+        String errorMessage = patchContext.error().toString();
+
+        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.SOFTWARE);
+        assertThat(errorMessage).contains(
+                "Connectors must be in the STOPPED state before their offsets can be modified. This can be done for the specified connector by issuing a 'PUT' request to the '/connectors/patch-offsets-test1/stop' endpoint");
+    }
+
+    @Test
+    public void offsets_are_correctly_patched() throws IOException {
+
+        registerTestConnector("patch-offsets-test1");
+
+        await()
+                .atMost(Duration.ofSeconds(OFFSET_AVAILABILITY_TIMEOUT_SECONDS))
+                .until(() -> {
+                    patchContext.reset();
+
+                    // No offsets have been committed yet; wait a little longer for an offset commit to complete
+                    return isOffsetAvailable("patch-offsets-test1");
+                });
+
+        // Sanity check: make sure that the connector has only published one kind of source offset
+        assertEquals(1, getOffsets("patch-offsets-test1").offsets().size());
+
+        stopContext.runAndEnsureExitCodeOk("patch-offsets-test1");
+        kafkaConnect.ensureConnectorState("patch-offsets-test1", Connector.State.STOPPED);
+
+        String sourcePartition = "{\"sourceClusterAlias\": \"kcctl-test-src\", \"targetClusterAlias\": \"kcctl-test-dst\"}";
+        String sourceOffset = "{\"offset\": 0}";
+        int exitCode = patchContext.commandLine().execute(
+                "--source-partition", sourcePartition,
+                "--source-offset", sourceOffset,
+                "patch-offsets-test1");
+        String output = patchContext.output().toString();
+
+        assertThat(exitCode).isEqualTo(CommandLine.ExitCode.OK);
+        assertThat(output).isEqualTo("The offsets for this connector have been altered successfully\n");
+
+        // Sanity check: make sure that the second offset can be read back
+        await()
+                .atMost(Duration.ofSeconds(OFFSET_AVAILABILITY_TIMEOUT_SECONDS))
+                .until(() -> getOffsets("patch-offsets-test1").offsets().size() == 2);
+    }
+
+    private boolean isOffsetAvailable(String connectorName) throws IOException {
+        return !getOffsets(connectorName).offsets().isEmpty();
+    }
+
+    private ConnectorOffsets getOffsets(String connectorName) throws IOException {
+        getContext.reset();
+        getContext.runAndEnsureExitCodeOk(connectorName);
+        String output = getContext.output().toString();
+        return mapper.readValue(output, ConnectorOffsets.class);
+    }
+
+}


### PR DESCRIPTION
Fixes #374 

Usage:

```
Usage: kcctl patch offsets [-h] [[--kafka-topic=<topic>
                           --kafka-partition=<partition>
                           --kafka-offset=<offset>] |
                           [--source-partition=<partition>
                           --source-offset=<offset>]] NAME
Patches committed connector offsets
      NAME     Name of the connector (e.g. 'my-connector')
  -h, --help   Show this help message and exit.
      --kafka-offset=<offset>
               Desired offset of the Kafka topic (for sink connectors)
      --kafka-partition=<partition>
               Partition of the Kafka topic (for sink connectors)
      --kafka-topic=<topic>
               Name of the Kafka topic (for sink connectors)
      --source-offset=<offset>
               Desired offset (for source connectors), as a JSON object
      --source-partition=<partition>
               Partition (for source connectors), as a JSON object
```

Uses the `PATCH /connectors/{name}/offsets}` endpoint introduced in [KIP-875](https://cwiki.apache.org/confluence/display/KAFKA/KIP-875%3A+First-class+offsets+support+in+Kafka+Connect#KIP875:FirstclassoffsetssupportinKafkaConnect-Endpoints) to alter offsets for a connector.

If the connector is a source connector, then the `--source-partition` and `--source-offset` options must both be supplied. If the connector is a sink connector, then then `--kafka-topic`, `--kafka-partition`, and `--kafka-offset` options must all be supplied. Options for sink connectors are mutually exclusive with options for source connectors; only options from one group may be provided.

Currently, only one offset can be altered per command. We may pursue en-masse offset patching later, to enable use cases like easily copying offsets from one connector/cluster over to another.


Other changes not directly related to the new command:
- d001ac0: Pick up some autoformatting changes that weren't applied in previous PRs
- a3a375b: Tiny bit of cleanup in the `DeleteOffsetsCommand` class (I was in the neighborhood copy+pasting this class as the foundation for the `PatchOffsetsCommand` class)
- 3807322: Add a new Debezium connector to the expected output of our integration tests (which fail on some versions of Debezium otherwise)
- 7c5ac12: Adapt integration tests to the new `last_modified` field that shows up in some of the `/admin/loggers` endpoints since [KIP-976](https://cwiki.apache.org/confluence/display/KAFKA/KIP-976%3A+Cluster-wide+dynamic+log+adjustment+for+Kafka+Connect) was merged