### PR TITLE
#395 Add '--scope' argument to 'patch logger'

### DIFF
--- a/kcctl_completion
+++ b/kcctl_completion
@@ -863,8 +863,9 @@ function _picocli_kcctl_patch_logger() {
 
   local commands=""
   local flag_opts="-h --help"
-  local arg_opts="-l --level"
+  local arg_opts="-l --level -s --scope"
   local level_option_args=("ERROR" "WARN" "FATAL" "DEBUG" "INFO" "TRACE") # --level values
+  local scope_option_args=("worker" "cluster") # --scope values
 
   type compopt &>/dev/null && compopt +o default
 
@@ -872,6 +873,11 @@ function _picocli_kcctl_patch_logger() {
     -l|--level)
       local IFS=$'\n'
       COMPREPLY=( $( compReplyArray "${level_option_args[@]}" ) )
+      return $?
+      ;;
+    -s|--scope)
+      local IFS=$'\n'
+      COMPREPLY=( $( compReplyArray "${scope_option_args[@]}" ) )
       return $?
       ;;
   esac

--- a/src/main/java/org/kcctl/command/LoggerNamesCompletionCandidateCommand.java
+++ b/src/main/java/org/kcctl/command/LoggerNamesCompletionCandidateCommand.java
@@ -15,17 +15,13 @@
  */
 package org.kcctl.command;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import java.util.Set;
 
 import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.kcctl.service.KafkaConnectApi;
 import org.kcctl.util.ConfigurationContext;
-
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
@@ -56,11 +52,7 @@ public class LoggerNamesCompletionCandidateCommand implements Runnable {
                 .baseUri(context.getCurrentContext().getCluster())
                 .build(KafkaConnectApi.class);
 
-        ObjectNode connectorLoggers = kafkaConnectApi.getLoggers("");
-        Iterator<String> fieldNames = connectorLoggers.fieldNames();
-        List<String> loggers = new ArrayList<>();
-        fieldNames.forEachRemaining(loggers::add);
-
+        Set<String> loggers = kafkaConnectApi.getLoggers().keySet();
         spec.commandLine().getOut().println(String.join(" ", loggers));
     }
 }

--- a/src/main/java/org/kcctl/service/KafkaConnectApi.java
+++ b/src/main/java/org/kcctl/service/KafkaConnectApi.java
@@ -31,8 +31,6 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 @Path("/")
 @RegisterRestClient
 @RegisterClientHeaders(value = KafkaConnectClientHeadersFactory.class)
@@ -140,5 +138,9 @@ public interface KafkaConnectApi {
 
     @GET
     @Path("/admin/loggers/{path}")
-    ObjectNode getLoggers(@PathParam("path") String path);
+    LoggerLevel getLogger(@PathParam("path") String path);
+
+    @GET
+    @Path("/admin/loggers")
+    Map<String, LoggerLevel> getLoggers();
 }

--- a/src/main/java/org/kcctl/service/KafkaConnectApi.java
+++ b/src/main/java/org/kcctl/service/KafkaConnectApi.java
@@ -134,6 +134,10 @@ public interface KafkaConnectApi {
     @Path("/admin/loggers/{classPath}")
     List<String> updateLogLevel(@PathParam("classPath") String classPath, String content);
 
+    @PUT
+    @Path("/admin/loggers/{classPath}")
+    String updateLogLevelWithScope(@PathParam("classPath") String classPath, @QueryParam("scope") String scope, String content);
+
     @GET
     @Path("/admin/loggers/{path}")
     ObjectNode getLoggers(@PathParam("path") String path);

--- a/src/main/java/org/kcctl/service/LoggerLevel.java
+++ b/src/main/java/org/kcctl/service/LoggerLevel.java
@@ -1,0 +1,21 @@
+/*
+ *  Copyright 2021 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.kcctl.service;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record LoggerLevel(@JsonProperty("level")String level, @JsonProperty("last_modified") Long lastModified) {
+}

--- a/src/test/java/org/kcctl/command/PatchLogLevelCommandTest.java
+++ b/src/test/java/org/kcctl/command/PatchLogLevelCommandTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024 The original authors
+ *  Copyright 2021 The original authors
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/org/kcctl/command/PatchLogLevelCommandTest.java
+++ b/src/test/java/org/kcctl/command/PatchLogLevelCommandTest.java
@@ -1,0 +1,145 @@
+/*
+ *  Copyright 2024 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.kcctl.command;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.kcctl.IntegrationTest;
+import org.kcctl.IntegrationTestProfile;
+import org.kcctl.service.LoggerLevel;
+import org.kcctl.support.InjectCommandContext;
+import org.kcctl.support.KcctlCommandContext;
+import org.kcctl.support.SkipIfConnectVersionIsOlderThan;
+
+import io.debezium.testing.testcontainers.DebeziumContainer;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+@TestProfile(IntegrationTestProfile.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SkipIfConnectVersionIsOlderThan("2.4")
+class PatchLogLevelCommandTest extends IntegrationTest {
+
+    private static final Duration CLUSTER_LOG_PATCH_TIMEOUT = Duration.ofSeconds(30);
+
+    @InjectCommandContext
+    KcctlCommandContext<PatchLogLevelCommand> context;
+
+    @InjectCommandContext
+    KcctlCommandContext<GetLoggerCommand> getContext;
+
+    @Test
+    public void should_patch_single_worker_with_no_scope() {
+        testSingleWorker(null);
+    }
+
+    @Test
+    public void should_patch_single_worker_with_worker_scope() {
+        testSingleWorker("worker");
+    }
+
+    @Test
+    public void should_patch_single_worker_with_unknown_scope() {
+        testSingleWorker("unknown");
+    }
+
+    private void testSingleWorker(String scope) {
+        String level = "WARN";
+        runPatchCommand(level, scope, "root");
+        Map<String, LoggerLevel> loggers = getContext.command().allLoggers();
+        assertLogLevels(level, loggers);
+        getContext.reset();
+
+        level = "INFO";
+        runPatchCommand(level, scope, "root");
+        loggers = getContext.command().allLoggers();
+        assertLogLevels(level, loggers);
+        getContext.reset();
+    }
+
+    @Test
+    @SkipIfConnectVersionIsOlderThan("3.7")
+    public void should_patch_all_workers_with_cluster_scope() {
+        try (DebeziumContainer secondWorker = secondWorker()) {
+            KcctlCommandContext<GetLoggerCommand> getContextSecondWorker = prepareContext(GetLoggerCommand.class, secondWorker);
+            String level = "WARN";
+            runPatchCommand(level, "cluster", "root");
+            assertAllLogLevels(level, getContext, getContextSecondWorker);
+
+            level = "INFO";
+            runPatchCommand(level, "cluster", "root");
+            assertAllLogLevels(level, getContext, getContextSecondWorker);
+        }
+    }
+
+    private void runPatchCommand(String level, String scope, String logger) {
+        context.reset();
+        List<String> args = new ArrayList<>();
+        args.add("-l");
+        args.add(level);
+        if (scope != null) {
+            args.add("-s");
+            args.add(scope);
+        }
+        args.add(logger);
+        context.runAndEnsureExitCodeOk(args.toArray(new String[0]));
+    }
+
+    private void assertLogLevels(String expectedLevel, Map<String, LoggerLevel> loggers) {
+        assertTrue(loggers.size() >= 2);
+        loggers.forEach((logger, loggerLevel) -> assertEquals(
+                expectedLevel,
+                loggerLevel.level().toUpperCase(Locale.ROOT),
+                "invalid level for logger '" + logger + "'"));
+    }
+
+    @SafeVarargs
+    private void assertAllLogLevels(String expectedLevel, KcctlCommandContext<GetLoggerCommand>... commands) {
+        await()
+                .atMost(CLUSTER_LOG_PATCH_TIMEOUT)
+                .until(() -> {
+                    for (KcctlCommandContext<GetLoggerCommand> commandContext : commands) {
+                        Map<String, LoggerLevel> firstWorkerLoggers = commandContext.command().allLoggers();
+                        try {
+                            assertLogLevels(expectedLevel, firstWorkerLoggers);
+                        }
+                        finally {
+                            commandContext.reset();
+                        }
+                    }
+                    return true;
+                });
+    }
+
+    private DebeziumContainer secondWorker() {
+        DebeziumContainer result = debeziumContainer();
+        result.start();
+        return result;
+    }
+
+}


### PR DESCRIPTION
Fixes #395

New usage:

```
Usage: kcctl patch logger [-h] -l=<level> [-s=<scope>] Logger NAME
Changes the log level of given class/Connector path
      Logger NAME       Name of the logger
  -h, --help            Show this help message and exit.
  -l, --level=<level>   Name of log level to apply
  -s, --scope=<scope>   The scope of the logging adjustment; e.g., 'worker' or
                          'cluster'
```

If a scope is provided, then it is included in the REST request via the `?scope` URL query parameter; if no scope is provided, the URL query parameter is omitted from the request.

There is no restriction on permitted values for scopes, but only the values "worker" and "cluster" are suggested during autocompletion.

Other changes not directly related to the new command:

- 7a92d18: Pick up some autoformatting changes that weren't applied in previous PRs
- c8c18aa: Adapt integration tests to the new `last_modified` field that shows up in some of the `/admin/loggers` endpoints since [KIP-976](https://cwiki.apache.org/confluence/display/KAFKA/KIP-976%3A+Cluster-wide+dynamic+log+adjustment+for+Kafka+Connect) was merged
- 60ede5f: Some tweaks to the `GetLoggerCommand` and `GetLoggersCommand` classes to make it easier to programmatically retrieve and inspect log levels from tests for other commands