### PR TITLE
MINOR: Update Debezium/Kafka Connect versions used in integration tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -61,6 +61,7 @@ jobs:
           TRUNK, # For testing new features not yet released
           NIGHTLY, # Bleeding edge snapshot builds from Debezium; can optionally disable this version during CI testing if an upstream bug causes test failures
           LATEST_STABLE,
+          "3.6",
           "3.5",
           "3.4",
           "3.3",

--- a/src/main/java/org/kcctl/command/GetLoggersCommand.java
+++ b/src/main/java/org/kcctl/command/GetLoggersCommand.java
@@ -16,7 +16,7 @@
 package org.kcctl.command;
 
 import java.util.Iterator;
-import java.util.Map;
+import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -72,12 +72,14 @@ public class GetLoggersCommand implements Runnable {
 
         int i = 0;
         for (final JsonNode header : (Iterable<JsonNode>) connectorLoggers::elements) {
-            for (final Map.Entry<String, JsonNode> field : (Iterable<Map.Entry<String, JsonNode>>) header::fields) {
-                data[i] = new String[]{
-                        classPaths.next(),
-                        " " + field.getValue().textValue()
-                };
-            }
+            String level = Optional.ofNullable(header.get("level"))
+                    .map(JsonNode::textValue)
+                    .orElse("null");
+            data[i] = new String[]{
+                    classPaths.next(),
+                    " " + level
+            };
+            // TODO: Add last_modified field to table
             i++;
         }
         spec.commandLine().getOut().println();

--- a/src/test/java/org/kcctl/IntegrationTest.java
+++ b/src/test/java/org/kcctl/IntegrationTest.java
@@ -96,7 +96,8 @@ public abstract class IntegrationTest {
             case TRUNK_BUILD -> TRUNK_BUILD;
             case NIGHTLY_BUILD -> "nightly";
             case LATEST_STABLE_BUILD -> ContainerImageVersions.getStableVersion(IntegrationTest.DEBEZIUM_IMAGE);
-            case "3.5" -> "2.4.0.Alpha1"; // TODO: Replace with stable version once one is released for 3.5.x; see https://github.com/kcctl/kcctl/issues/346
+            case "3.6" -> "2.5.0.Final";
+            case "3.5" -> "2.4.2.Final";
             case "3.4" -> "2.3.0.Final";
             case "3.3" -> "2.1.4.Final";
             case "3.2" -> "1.9.7.Final";

--- a/src/test/java/org/kcctl/command/GetPluginsCommandTest.java
+++ b/src/test/java/org/kcctl/command/GetPluginsCommandTest.java
@@ -41,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class GetPluginsCommandTest extends IntegrationTest {
 
     private static final Version SPANNER_CONNECTOR_MIN_VERSION = new Version(2, 1);
+    private static final Version INFORMIX_CONNECTOR_MIN_VERSION = new Version(2, 5);
     private static final Version MIRROR_MAKER_MIN_GRANULAR_VERSION = new Version(3, 2);
     private static final Version FILE_CONNECTOR_REMOVAL_MIN_VERSION = new Version(3, 2); // Also removed in 3.1.1 (see https://issues.apache.org/jira/browse/KAFKA-13748) but there's no Debezium image built off of that so 3.2.x is fine
 
@@ -60,6 +61,11 @@ class GetPluginsCommandTest extends IntegrationTest {
             spannerConnectorDescription = "source   io.debezium.connector.spanner.SpannerConnector              " + debeziumVersion;
         }
 
+        String informixConnectorDescription = null;
+        if (parsedDebeziumVersion.greaterOrEquals(INFORMIX_CONNECTOR_MIN_VERSION)) {
+            informixConnectorDescription = "source   io.debezium.connector.informix.InformixConnector            " + debeziumVersion;
+        }
+
         String mirrorMakerVersion = "1";
         if (parsedKafkaVersion.greaterOrEquals(MIRROR_MAKER_MIN_GRANULAR_VERSION)) {
             mirrorMakerVersion = kafkaVersion;
@@ -73,6 +79,7 @@ class GetPluginsCommandTest extends IntegrationTest {
         String[] expectedOutput = Stream.of(
                 "TYPE     CLASS                                                       VERSION",
                 "source   io.debezium.connector.db2.Db2Connector                      " + debeziumVersion,
+                informixConnectorDescription,
                 "source   io.debezium.connector.mongodb.MongoDbConnector              " + debeziumVersion,
                 "source   io.debezium.connector.mysql.MySqlConnector                  " + debeziumVersion,
                 "source   io.debezium.connector.oracle.OracleConnector                " + debeziumVersion,


### PR DESCRIPTION
Adds a final Debezium tag to use for Kafka Connect 3.5, and a new tag to use for Kafka Connect 3.6.

Also brings in a few other unrelated commits to make CI happy.