### PR TITLE
Simplify release

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -1,5 +1,5 @@
 #
-#  Copyright 2021 The original authors
+#  Copyright 2021-2024 The original authors
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -25,16 +25,67 @@ env:
   JAVA_DISTRO: 'temurin'
 
 jobs:
-  # Build native executable per runner
-  build:
-    name: 'Build with Graal on ${{ matrix.os }}'
+  precheck:
     if: github.repository == 'kcctl/kcctl' && startsWith(github.event.head_commit.message, '🏁 Releasing version') != true && startsWith(github.event.head_commit.message, '⬆️  Next version') != true
+    runs-on: ubuntu-latest
+    outputs:
+      VERSION: ${{ steps.vars.outputs.VERSION }}
+    steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@v4
+
+      - name: 'Cancel previous run'
+        uses: styfle/cancel-workflow-action@0.12.0
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Set up Java'
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRO }}
+          cache: maven
+
+      - name: 'Version'
+        id: vars
+        shell: bash
+        run: |
+          version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "VERSION=$(echo $version)" >> $GITHUB_OUTPUT
+
+  build:
+    depends: [ precheck ]
+    if: endsWith(${{ needs.precheck.outputs.VERSION }}, '-SNAPSHOT')
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@v4
+
+      - name: 'Add Developer Command Prompt for Microsoft Visual C++ '
+        if: ${{ runner.os == 'Windows' }}
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: 'Set up Graal'
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: 'graalvm-community'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache: maven
+
+      - name: 'Build'
+        if: ${{ runner.os == 'Linux' }}
+        run: ./mvnw -ntp -B --file pom.xml test
+
+  # Build native executable per runner
+  package:
+    depends: [ build ]
+    name: 'Build with Graal on ${{ matrix.os }}'
     strategy:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
-
     steps:
       - name: 'Check out repository'
         uses: actions/checkout@v4
@@ -43,26 +94,21 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         uses: ilammy/msvc-dev-cmd@v1
 
-      - uses: graalvm/setup-graalvm@v1
+      - name: 'Set up Graal'
+        uses: graalvm/setup-graalvm@v1
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'graalvm-community'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: 'Cache Maven packages'
-        uses: actions/cache@v4.0.0
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: maven
 
       - name: 'Build Native Image (Linux)'
         if: ${{ runner.os == 'Linux' }}
-        run: ./mvnw -ntp -B --file pom.xml -Pnative package
+        run: ./mvnw -ntp -B --file pom.xml -Pnative package -DskipTests
 
       - name: 'Build Native Image (macOS, Windows)'
         if: ${{ runner.os == 'macOS' || runner.os == 'Windows' }}
-        run: ./mvnw -ntp -B --file pom.xml -Pnative package "-Dquarkus.test.profile.tags=basic"
+        run: ./mvnw -ntp -B --file pom.xml -Pnative package -DskipTests "-Dquarkus.test.profile.tags=basic"
 
       - name: 'Create distribution'
         run: ./mvnw -ntp -B --file pom.xml -Pdist package -DskipTests
@@ -77,9 +123,8 @@ jobs:
 
   # Collect all executables and release
   release:
-    needs: [ build ]
+    needs: [ package ]
     runs-on: ubuntu-latest
-
     steps:
       - name: 'Check out repository'
         uses: actions/checkout@v4
@@ -94,20 +139,14 @@ jobs:
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRO }}
-
-      - name: 'Cache Maven packages'
-        uses: actions/cache@v4.0.0
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: maven
 
       - name: 'Release with JReleaser'
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./mvnw -ntp -B --file pom.xml -Prelease -DartifactsDir=artifacts jreleaser:full-release
 
-      - name: JReleaser output
+      - name: 'JReleaser output'
         if: always()
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -105,7 +105,7 @@ jobs:
       - name: 'Release with JReleaser'
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./mvnw -ntp -B --file pom.xml -Pea-release -DartifactsDir=artifacts jreleaser:full-release
+        run: ./mvnw -ntp -B --file pom.xml -Prelease -DartifactsDir=artifacts jreleaser:full-release
 
       - name: JReleaser output
         if: always()

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -114,9 +114,9 @@ jobs:
         run: ./mvnw -ntp -B --file pom.xml -Pdist package -DskipTests
 
       - name: 'Upload build artifact'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: artifacts-${{ matrix.os }}
           path: |
             target/*.zip
             target/*.tar.gz
@@ -132,7 +132,11 @@ jobs:
           fetch-depth: 0
 
       - name: 'Download all build artifacts'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: artifacts-*
+          merge-multiple: true
 
       - name: 'Set up Java'
         uses: actions/setup-java@v4
@@ -148,7 +152,7 @@ jobs:
 
       - name: 'JReleaser output'
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jreleaser-logs
           path: |

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,5 +1,5 @@
 #
-#  Copyright 2021 The original authors
+#  Copyright 2021-2024 The original authors
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ jobs:
   build:
     if: startsWith(github.event.head_commit.message, '🏁 Releasing version') != true && startsWith(github.event.head_commit.message, '⬆️  Next version') != true
     runs-on: ubuntu-latest
-
     steps:
       - name: 'Check out repository'
         uses: actions/checkout@v4
@@ -40,13 +39,7 @@ jobs:
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRO }}
-
-      - name: 'Cache Maven packages'
-        uses: actions/cache@v4.0.0
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: maven
 
       - name: 'Build'
         run: ./mvnw -ntp -B --file pom.xml verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,9 +136,9 @@ jobs:
         run: ./mvnw -ntp -B --file pom.xml -Pdist package -DskipTests
 
       - name: 'Upload build artifact'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: artifacts-${{ matrix.os }}
           path: |
             target/*.zip
             target/*.tar.gz
@@ -157,7 +157,11 @@ jobs:
       # checkout will clobber downloaded artifacts
       # we have to download them again
       - name: 'Download all build artifacts'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: artifacts-*
+          merge-multiple: true
 
       - name: 'Set up Java'
         uses: actions/setup-java@v4
@@ -176,7 +180,7 @@ jobs:
 
       - name: 'JReleaser output'
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jreleaser-logs
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 #
-#  Copyright 2021 The original authors
+#  Copyright 2021-2024 The original authors
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -40,20 +40,15 @@ jobs:
       PLAIN_VERSION: ${{ steps.version.outputs.PLAIN_VERSION }}
       NEXT_VERSION: ${{ steps.version.outputs.NEXT_VERSION }}
     steps:
-      - uses: actions/checkout@v4
+      - name: 'Check out repository'
+        uses: actions/checkout@v4
 
       - name: 'Set up Java'
         uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRO }}
-
-      - name: 'Cache Maven packages'
-        uses: actions/cache@v4.0.0
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: maven
 
       - name: 'Set release version'
         id: version
@@ -77,9 +72,34 @@ jobs:
           echo "NEXT_VERSION=$NEXT_VERSION" >> $GITHUB_OUTPUT
           echo "PLAIN_VERSION=$PLAIN_VERSION" >> $GITHUB_OUTPUT
 
-  # Build native executable per runner
   build:
-    needs: [ version ]
+    depends: [ version ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.version.outputs.HEAD }}
+
+      - name: 'Add Developer Command Prompt for Microsoft Visual C++ '
+        if: ${{ runner.os == 'Windows' }}
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: 'Set up Graal'
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: 'graalvm-community'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache: maven
+
+      - name: 'Build'
+        if: ${{ runner.os == 'Linux' }}
+        run: ./mvnw -ntp -B --file pom.xml test
+
+  # Build native executable per runner
+  package:
+    needs: [ version, build ]
     name: 'Build with Graal on ${{ matrix.os }}'
     strategy:
       fail-fast: true
@@ -96,26 +116,21 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         uses: ilammy/msvc-dev-cmd@v1
 
-      - uses: graalvm/setup-graalvm@v1
+      - name: 'Set up Graal'
+        uses: graalvm/setup-graalvm@v1
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'graalvm-community'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: 'Cache Maven packages'
-        uses: actions/cache@v4.0.0
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: maven
 
       - name: 'Build Native Image (Linux)'
         if: ${{ runner.os == 'Linux' }}
-        run: ./mvnw -ntp -B --file pom.xml -Pnative package
+        run: ./mvnw -ntp -B --file pom.xml -Pnative package -DskipTests
 
       - name: 'Build Native Image (macOS, Windows)'
         if: ${{ runner.os == 'macOS' || runner.os == 'Windows' }}
-        run: ./mvnw -ntp -B --file pom.xml -Pnative package "-Dquarkus.test.profile.tags=basic"
+        run: ./mvnw -ntp -B --file pom.xml -Pnative package -DskipTests "-Dquarkus.test.profile.tags=basic"
 
       - name: 'Create distribution'
         run: ./mvnw -ntp -B --file pom.xml -Pdist package -DskipTests
@@ -130,7 +145,7 @@ jobs:
 
   # Collect all executables and release
   release:
-    needs: [ version, build ]
+    needs: [ version, package ]
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out repository'
@@ -149,13 +164,7 @@ jobs:
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRO }}
-
-      - name: 'Cache Maven packages'
-        uses: actions/cache@v4.0.0
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: maven
 
       - name: 'Release with JReleaser'
         env:
@@ -165,7 +174,7 @@ jobs:
           JRELEASER_HOMEBREW_GITHUB_TOKEN: ${{ secrets.JRELEASER_HOMEBREW_GITHUB_TOKEN }}
         run: ./mvnw -ntp -B --file pom.xml -Prelease -DartifactsDir=artifacts jreleaser:full-release
 
-      - name: JReleaser output
+      - name: 'JReleaser output'
         if: always()
         uses: actions/upload-artifact@v3
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -452,97 +452,6 @@
       </properties>
     </profile>
     <profile>
-      <id>ea-release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.jreleaser</groupId>
-            <artifactId>jreleaser-maven-plugin</artifactId>
-            <version>1.10.0</version>
-            <configuration>
-              <jreleaser>
-                <project>
-                  <snapshot>
-                    <label>{{ projectVersionNumber }}-early-access</label>
-                  </snapshot>
-                </project>
-                <release>
-                  <github>
-                    <changelog>
-                      <formatted>ALWAYS</formatted>
-                      <includeLabels>
-                        <includeLabel>changes</includeLabel>
-                        <includeLabel>dependencies</includeLabel>
-                      </includeLabels>
-                      <labelers>
-                        <labeler>
-                          <label>changes</label>
-                          <title>regex:^(?!Bump \S+ from \S+ to \S+).+$</title>
-                        </labeler>
-                        <labeler>
-                          <label>dependencies</label>
-                          <title>regex:^Bump \S+ from \S+ to \S+</title>
-                        </labeler>
-                      </labelers>
-                      <categories>
-                        <category>
-                          <title>🔄 Changes</title>
-                          <key>changes</key>
-                          <labels>changes</labels>
-                          <order>1</order>
-                        </category>
-                        <category>
-                          <title>⚙️ Dependencies</title>
-                          <key>dependencies</key>
-                          <labels>dependencies</labels>
-                          <order>2</order>
-                        </category>
-                      </categories>
-                    </changelog>
-                  </github>
-                </release>
-                <distributions>
-                  <kcctl>
-                    <name>kcctl</name>
-                    <type>BINARY</type>
-                    <brew>
-                      <active>RELEASE</active>
-                      <multiPlatform>true</multiPlatform>
-                    </brew>
-                    <sdkman>
-                      <active>RELEASE</active>
-                    </sdkman>
-                    <artifacts>
-                      <artifact>
-                        <path>{{artifactsDir}}/{{distributionName}}-{{projectVersion}}-linux-x86_64.tar.gz</path>
-                        <transform>artifacts/{{distributionName}}-{{projectEffectiveVersion}}-linux-x86_64.tar.gz</transform>
-                        <platform>linux-x86_64</platform>
-                      </artifact>
-                      <artifact>
-                        <path>{{artifactsDir}}/{{distributionName}}-{{projectVersion}}-linux-x86_64.zip</path>
-                        <transform>artifacts/{{distributionName}}-{{projectEffectiveVersion}}-linux-x86_64.zip</transform>
-                        <platform>linux-x86_64</platform>
-                      </artifact>
-                      <artifact>
-                        <path>{{artifactsDir}}/{{distributionName}}-{{projectVersion}}-windows-x86_64.zip</path>
-                        <transform>artifacts/{{distributionName}}-{{projectEffectiveVersion}}-windows-x86_64.zip</transform>
-                        <platform>windows-x86_64</platform>
-                      </artifact>
-                      <artifact>
-                        <path>{{artifactsDir}}/{{distributionName}}-{{projectVersion}}-osx-x86_64.zip</path>
-                        <transform>artifacts/{{distributionName}}-{{projectEffectiveVersion}}-osx-x86_64.zip</transform>
-                        <platform>osx-x86_64</platform>
-                      </artifact>
-                    </artifacts>
-                  </kcctl>
-                </distributions>
-              </jreleaser>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>release</id>
       <build>
         <plugins>
@@ -628,11 +537,13 @@
                         <path>{{artifactsDir}}/{{distributionName}}-{{projectVersion}}-osx-aarch_64.tar.gz</path>
                         <transform>artifacts/{{distributionName}}-{{projectEffectiveVersion}}-osx-aarch_64.tar.gz</transform>
                         <platform>osx-aarch_64</platform>
+                        <active>RELEASE</active>
                       </artifact>
                       <artifact>
                         <path>{{artifactsDir}}/{{distributionName}}-{{projectVersion}}-osx-aarch_64.zip</path>
                         <transform>artifacts/{{distributionName}}-{{projectEffectiveVersion}}-osx-aarch_64.zip</transform>
                         <platform>osx-aarch_64</platform>
+                        <active>RELEASE</active>
                       </artifact>
                     </artifacts>
                   </kcctl>


### PR DESCRIPTION
- Remove duplicate release configuration
- Perform a build on Linux before packaging per platform
- Skip running tests during packaging
- Upgrade upload/download GH actions