### PR TITLE
#422 Fix NPE for 'kcctl patch offsets' without payload

### DIFF
--- a/src/main/java/org/kcctl/command/PatchOffsetsCommand.java
+++ b/src/main/java/org/kcctl/command/PatchOffsetsCommand.java
@@ -132,7 +132,7 @@ public class PatchOffsetsCommand implements Callable<Integer> {
         }
     }
 
-    @CommandLine.ArgGroup(exclusive = true)
+    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
     PatchedConnectorOffset patchedOffset;
 
     @Inject

--- a/src/test/java/org/kcctl/command/PatchOffsetsCommandTest.java
+++ b/src/test/java/org/kcctl/command/PatchOffsetsCommandTest.java
@@ -116,6 +116,28 @@ class PatchOffsetsCommandTest extends IntegrationTest {
                 .until(() -> getOffsets("patch-offsets-test1").offsets().size() == 2);
     }
 
+    @Test
+    public void require_offset_argument() {
+        int exitCode = patchContext.commandLine().execute("some-connector");
+        assertEquals(CommandLine.ExitCode.USAGE, exitCode);
+        assertThat(patchContext.error().toString()).contains("Missing required argument ");
+    }
+
+    @Test
+    public void disallow_multiple_offset_arguments() {
+        String sourcePartition = "{\"sourceClusterAlias\": \"kcctl-test-src\", \"targetClusterAlias\": \"kcctl-test-dst\"}";
+        String sourceOffset = "{\"offset\": 0}";
+        int exitCode = patchContext.commandLine().execute(
+                "--source-partition", sourcePartition,
+                "--source-offset", sourceOffset,
+                "--kafka-topic", "topic",
+                "--kafka-partition", "0",
+                "--kafka-offset", "0",
+                "some-connector");
+        assertEquals(CommandLine.ExitCode.USAGE, exitCode);
+        assertThat(patchContext.error().toString()).contains("are mutually exclusive ");
+    }
+
     private boolean isOffsetAvailable(String connectorName) throws IOException {
         return !getOffsets(connectorName).offsets().isEmpty();
     }


### PR DESCRIPTION
Fixes #422, and adds some extra testing to ensure that the source and sink offset argument types are (and remain) mutually exclusive.